### PR TITLE
feat(#7): 사용자 인증 및 내 정보 관리 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/vitacheck/config/SecurityConfig.java
+++ b/src/main/java/com/vitacheck/config/SecurityConfig.java
@@ -1,0 +1,44 @@
+package com.vitacheck.config;
+
+import com.vitacheck.config.jwt.JwtAuthenticationFilter;
+import com.vitacheck.config.jwt.JwtUtil;
+import com.vitacheck.config.oauth.OAuth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final JwtUtil jwtUtil;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/", "/oauth2/**", "/login/**", "/error").permitAll()
+                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .anyRequest().authenticated())
+                .oauth2Login(oauth2 -> oauth2
+                        .successHandler(oAuth2SuccessHandler)
+                        // .userInfoEndpoint(userInfo -> userInfo.userService(oAuth2UserService))
+                );
+
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/vitacheck/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/vitacheck/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,51 @@
+package com.vitacheck.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.security.Security;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+        throws ServletException, IOException {
+
+        // 1. 헤더에서 Authorization을 찾은 후 Bearer 토큰 추출
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request,response);
+            return;
+        }
+        String token = authorizationHeader.substring(7);
+
+        // 2. 토큰 검증
+        if (jwtUtil.validateToken(token)) {
+            // 3. 토큰 유효 -> 사용자 정보 추출 -> Authentication 객체 생성
+            String email = jwtUtil.getEmailFromToken(token);
+
+            // DB 조회 X -> 토큰 정보로 인증 객체 생성
+            UserDetails userDetails = new User(email, "", Collections.emptyList());
+            Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+
+            // 4. SecurityContext에 인증 객체 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request,response);
+    }
+}

--- a/src/main/java/com/vitacheck/config/jwt/JwtUtil.java
+++ b/src/main/java/com/vitacheck/config/jwt/JwtUtil.java
@@ -1,0 +1,79 @@
+package com.vitacheck.config.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private final Key key;
+    private final long accessTokenExpTime;
+    private final long refreshTokenExpTime;
+    private static final Logger log = LoggerFactory.getLogger(JwtUtil.class);
+
+    public JwtUtil(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-expiration-minutes}") long accessTokenExpTime,
+            @Value("${jwt.refresh-token-expiration-days}") long refreshTokenExpTime
+    ) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpTime = accessTokenExpTime * 60 * 1000; // 분 -> 밀리초
+        this.refreshTokenExpTime = refreshTokenExpTime * 24 * 60 * 60 * 1000; // 일 -> 밀리초
+    }
+
+    public String createAccessToken(String email) {
+        return createToken(email, accessTokenExpTime);
+    }
+
+    public String createRefreshToken(String email) {
+        return createToken(email, refreshTokenExpTime);
+    }
+
+    private String createToken(String email, long expirationTime) {
+        Claims claims = Jwts.claims();
+        claims.put("email", email);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expirationTime))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getEmailFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody().get("email", String.class);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            // 토큰 파싱 시도
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            // MalformedJwtException: JWT 형식이 잘못되었을 때
+            // SecurityException: 서명이 올바르지 않거나(위조), JWT 구조에 문제가 있을 때
+            log.warn("잘못된 JWT 서명입니다. (Invalid JWT signature)");
+        } catch (ExpiredJwtException e) {
+            // 토큰의 유효기간이 만료되었을 때
+            // 이 로그는 매우 흔하게 발생하므로 ERROR나 WARN 대신 INFO 레벨로 기록하는 것이 좋습니다.
+            log.info("만료된 JWT 토큰입니다. (Expired JWT token)");
+        } catch (UnsupportedJwtException e) {
+            // 지원되지 않는 형식의 JWT일 때
+            log.warn("지원되지 않는 JWT 토큰입니다. (Unsupported JWT token)");
+        } catch (IllegalArgumentException e) {
+            // JWT 클레임 문자열이 비어있거나, 토큰 값이 null일 때
+            log.warn("JWT 토큰이 잘못되었습니다. (JWT token is malformed or empty)");
+        }
+        // 위 예외 중 하나라도 발생하면 유효하지 않은 토큰이므로 false 반환
+        return false;
+    }
+}

--- a/src/main/java/com/vitacheck/config/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/vitacheck/config/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,62 @@
+package com.vitacheck.config.oauth;
+
+import com.vitacheck.config.jwt.JwtUtil;
+import com.vitacheck.domain.user.User;
+import com.vitacheck.dto.OAuthAttributes;
+import com.vitacheck.repository.UserRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+
+        // 1. 어떤 소셜 로그인인지 파악
+        OAuth2AuthenticationToken token = (OAuth2AuthenticationToken) authentication;
+        String provider = token.getAuthorizedClientRegistrationId();
+
+        // 2. OAuthAttributes 클래스 사용 -> 사용자 정보 통일
+        OAuthAttributes attributes = OAuthAttributes.of(provider, provider, oAuth2User.getAttributes());
+
+        // 가상 이메일 추가 -> provider, providerId로 사용자 찾기
+        User user = userRepository.findByProviderAndProviderId(attributes.getProvider(), attributes.getProviderId())
+                .orElseGet(() -> userRepository.save(attributes.toEntity()));
+
+        /*
+        // 3. DB에서 사용자 조회 -> 없으면 새로 만들기
+        User user = userRepository.findByEmail(attributes.getEmail())
+                .orElseGet(() -> userRepository.save(attributes.toEntity()));
+        */
+
+        // 4. JWT 생성
+        String accessToken = jwtUtil.createAccessToken(user.getEmail()); // 카카오는 가상 이메일 사용
+        String refreshToken = jwtUtil.createRefreshToken(user.getEmail());
+
+        // 5. 프론트엔드로 토큰을 담아 리다이렉트
+        String targetUrl = UriComponentsBuilder.fromUriString("http://localhost:3000/oauth-redirect")
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build().toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/com/vitacheck/controller/UserController.java
+++ b/src/main/java/com/vitacheck/controller/UserController.java
@@ -1,0 +1,34 @@
+package com.vitacheck.controller;
+
+import com.vitacheck.dto.UserDto;
+import com.vitacheck.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserDto.InfoResponse> getMyInfo(@AuthenticationPrincipal UserDetails userDetails){
+        String email = userDetails.getUsername();
+        UserDto.InfoResponse myInfo = userService.getMyInfo(email);
+        return ResponseEntity.ok(myInfo);
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<UserDto.InfoResponse> updateMyInfo(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody UserDto.UpdateRequest request
+    ) {
+        String email = userDetails.getUsername();
+        UserDto.InfoResponse updatedInfo = userService.updateMyInfo(email, request);
+        return ResponseEntity.ok(updatedInfo);
+    }
+}

--- a/src/main/java/com/vitacheck/domain/user/Role.java
+++ b/src/main/java/com/vitacheck/domain/user/Role.java
@@ -1,0 +1,5 @@
+package com.vitacheck.domain.user;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/com/vitacheck/domain/user/User.java
+++ b/src/main/java/com/vitacheck/domain/user/User.java
@@ -1,0 +1,31 @@
+package com.vitacheck.domain.user;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    private String provider; // 예: google, kakao
+    private String providerId; // 소셜 로그인 서비스 고유 ID
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/vitacheck/dto/OAuthAttributes.java
+++ b/src/main/java/com/vitacheck/dto/OAuthAttributes.java
@@ -1,0 +1,99 @@
+package com.vitacheck.dto;
+
+import com.vitacheck.domain.user.Role;
+import com.vitacheck.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuthAttributes {
+    private Map<String, Object> attributes;
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String provider;
+    private String providerId;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email, String provider, String providerId) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.provider = provider;
+        this.providerId = providerId;
+    }
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        if ("naver".equals(registrationId)) {
+            return ofNaver("id", attributes);
+        }
+        if ("kakao".equals(registrationId)) {
+            return ofKakao("id", attributes);
+        }
+        return ofGoogle(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .provider("google")
+                .providerId((String) attributes.get("sub"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        // Kakao는 응답이 중첩된 JSON 구조이므로, 필요한 정보를 꺼내야 합니다.
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
+        String providerId = String.valueOf(attributes.get("id"));
+
+        String email = null;
+        if (kakaoAccount != null) {
+            email = (String) kakaoAccount.get("email");
+        }
+        // 가상 이메일 생성
+        if (email == null || email.isBlank()) {
+            email = providerId + "@kakao.com";
+        }
+
+        return OAuthAttributes.builder()
+                .name((String) kakaoProfile.get("nickname"))
+                .email(email)
+                .provider("kakao")
+                .providerId(providerId)
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    private static OAuthAttributes ofNaver(String userNameAttributeName, Map<String, Object> attributes) {
+        // Naver는 응답이 response라는 키 값 내부에 중첩되어 있습니다.
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        return OAuthAttributes.builder()
+                .name((String) response.get("name"))
+                .email((String) response.get("email"))
+                .provider("naver")
+                .providerId((String) response.get("id"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    // 처음 가입하는 사용자일 경우, User 엔티티를 생성하는 메소드
+    public User toEntity() {
+        return User.builder()
+                .nickname(name)
+                .email(email)
+                .provider(provider)
+                .providerId(providerId)
+                .role(Role.USER) // 기본 권한은 USER
+                .build();
+    }
+}

--- a/src/main/java/com/vitacheck/dto/UserDto.java
+++ b/src/main/java/com/vitacheck/dto/UserDto.java
@@ -1,0 +1,20 @@
+package com.vitacheck.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserDto {
+    @Getter
+    @NoArgsConstructor
+    public static class UpdateRequest {
+        private String nickname;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class InfoResponse {
+        private String email;
+        private String nickname;
+    }
+}

--- a/src/main/java/com/vitacheck/repository/UserRepository.java
+++ b/src/main/java/com/vitacheck/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.vitacheck.repository;
+
+import com.vitacheck.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+
+    // 카카오 로그인 구현에서 이메일 제공 불가(애플리케이션 심사 필요) -> 가상 이메일 생성 메소드
+    Optional<User> findByProviderAndProviderId(String provider, String providerId);
+}

--- a/src/main/java/com/vitacheck/service/UserService.java
+++ b/src/main/java/com/vitacheck/service/UserService.java
@@ -1,0 +1,31 @@
+package com.vitacheck.service;
+
+import com.vitacheck.domain.user.User;
+import com.vitacheck.dto.UserDto;
+import com.vitacheck.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public UserDto.InfoResponse getMyInfo(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+        return new UserDto.InfoResponse(user.getEmail(), user.getNickname());
+    }
+
+    @Transactional
+    public UserDto.InfoResponse updateMyInfo(String email, UserDto.UpdateRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+        user.updateNickname(request.getNickname());
+        return new UserDto.InfoResponse(user.getEmail(), user.getNickname());
+    }
+}

--- a/src/main/resources/application-local.yml.example
+++ b/src/main/resources/application-local.yml.example
@@ -1,11 +1,61 @@
-# application-local.yml.example
+# 이 파일은 application-local.yml 파일에 어떤 내용이 필요한지 알려주는 템플릿입니다.
+# 이 파일을 복사하여 application-local.yml 을 만들고, 아래의 # 로 시작하는 설명에 따라 실제 값을 채워주세요.
+
 spring:
   datasource:
+    # 한글 및 시간 관련 문제를 방지하기 위한 옵션을 추가했습니다.
     url: jdbc:mysql://localhost:3306/vitacheck_db?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
-    username: # 여기에 각자 DB 아이디를 입력하세요.
-    password: # 여기에 각자 DB 비밀번호를 입력하세요.
+    username: # 여기에 각자 DB 아이디를 입력하세요 (예: root)
+    password: # 여기에 각자 DB 비밀번호를 입력하세요 (절대 커밋 금지!)
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: # Google Cloud Console에서 발급받은 클라이언트 ID
+            client-secret: # Google Cloud Console에서 발급받은 클라이언트 시크릿
+            scope:
+              - email
+              - profile
+          kakao:
+            client-id: # 카카오 디벨로퍼스에서 발급받은 REST API 키
+            client-secret: # 카카오 디벨로퍼스에서 발급받은 Client Secret
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname
+            client-name: Kakao
+          naver:
+            client-id: # 네이버 개발자 센터에서 발급받은 Client ID
+            client-secret: # 네이버 개발자 센터에서 발급받은 Client Secret
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            client-authentication-method: client_secret_post
+            authorization-grant-type: authorization_code
+            scope:
+              - name
+              - email
+            client-name: Naver
+
+        provider:
+          # Google은 Spring Boot가 자동 설정해주므로 생략 가능
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
   jpa:
     hibernate:
-      ddl-auto: update # 로컬에서는 update로 설정하여 개발 편의성 증대
+      ddl-auto: update
 
-# ... 기타 로컬에서만 필요한 설정 (예: JWT 시크릿 키)
+jwt:
+  secret: # 여기에 256비트 이상의 매우 긴 JWT 시크릿 키를 입력하세요 (절대 커밋 금지!)
+  access-token-expiration-minutes: 30
+  refresh-token-expiration-days: 14


### PR DESCRIPTION
Close #7

## 📝 작업 내용

Spring Security, OAuth2, JWT를 사용하여 프로젝트의 핵심 인증/보안 시스템을 구축했습니다. 사용자는 이제 구글, 카카오, 네이버를 통해 소셜 로그인을 할 수 있으며, 로그인 성공 시 서비스 전용 JWT(Access Token, Refresh Token)가 발급됩니다.

또한, 발급된 토큰으로 인증된 사용자는 자신의 정보를 조회하고 수정하는 API(`GET /me`, `PUT /me`)를 사용할 수 있습니다. 카카오/네이버 로그인 시 이메일 미동의 사용자를 위해, 고유 ID 기반의 가상 이메일을 생성하여 회원가입시키는 로직을 포함했습니다.

## ✅ 변경 사항

- **Spring Security & OAuth2/JWT 의존성 추가**
- **`application.yml`**: OAuth2 클라이언트(Google, Kakao, Naver) 및 JWT 관련 설정을 추가했습니다.
- **`User` 엔티티 / `UserRepository`**: 사용자 정보를 저장하기 위한 엔티티와 레포지토리를 생성했습니다. 소셜 로그인 제공자(`provider`)와 고유 ID(`providerId`)로 사용자를 조회하는 메소드를 추가했습니다.
- **`config/jwt` 패키지**:
    - `JwtUtil`: JWT 생성, 검증, 정보 추출 로직을 구현했습니다.
    - `JwtAuthenticationFilter`: API 요청 시 `Authorization` 헤더의 토큰을 검증하는 필터를 구현했습니다.
- **`config/oauth` 패키지**:
    - `OAuth2SuccessHandler`: 소셜 로그인 성공 후, 사용자를 DB에 저장/조회하고 서비스 전용 JWT를 발급하여 리다이렉트하는 로직을 구현했습니다.
- **`dto` 패키지**:
    - `OAuthAttributes`: 각 소셜 서비스의 상이한 사용자 정보 응답을 통일된 형태로 변환하는 로직을 구현했습니다.
    - `UserDto`: 내 정보 조회/수정 API에 사용될 DTO를 생성했습니다.
- **`config/SecurityConfig`**:
    - 위의 모든 컴포넌트(필터, 핸들러 등)를 사용하여 전체 보안 규칙 및 인증 흐름을 설정했습니다.
- **`UserController` / `UserService`**:
    - `GET /api/v1/users/me` (내 정보 조회) API를 구현했습니다.
    - `PUT /api/v1/users/me` (내 정보 수정) API를 구현했습니다.

## 💬 리뷰어에게

이 PR은 인증/보안의 핵심 골격을 구현하는 데 집중했습니다.

**추후 다른 팀원들의 작업이 완료되는 대로, 아래 내용은 별도의 리팩토링 PR을 통해 점진적으로 적용할 예정입니다:**
* **공통 응답 포맷**: 현재는 `ResponseEntity`를 직접 사용하지만, 추후 공통 `ApiResponse` 포맷으로 교체하겠습니다.
* **공통 예외 처리**: 현재는 `EntityNotFoundException` 등 표준 예외를 사용하지만, 추후 `@RestControllerAdvice`를 이용한 공통 예외 처리 로직을 적용하겠습니다.
* **API 문서화**: Swagger 설정이 완료되면, 본 PR에서 추가된 API들의 문서를 보강하겠습니다.
* **ERD 변경사항**: ERD가 확정되고 변경사항이 생기면, `User` 엔티티에 추가로 반영하겠습니다.

핵심 인증 흐름과 보안 설정에 문제가 없는지 중점적으로 리뷰 부탁드립니다!