### PR TITLE
docs(#12): UserController에 Swagger 문서화 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // jwt 의존성 0.12.5로 수정
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/vitacheck/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/vitacheck/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package com.vitacheck.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        // 응답 상태 코드를 401 Unauthorized로 설정
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        // 응답 컨텐츠 타입을 JSON으로 설정
+        response.setContentType("application/json;charset=UTF-8");
+
+        // 응답 바디에 담을 에러 메시지 생성
+        Map<String, Object> errorDetails = new HashMap<>();
+        errorDetails.put("error", "Unauthorized");
+        errorDetails.put("message", "인증이 필요합니다: " + authException.getMessage());
+
+        // ObjectMapper를 사용해 Map을 JSON 문자열로 변환하고, 응답 스트림에 쓴다.
+        response.getWriter().write(objectMapper.writeValueAsString(errorDetails));
+    }
+}

--- a/src/main/java/com/vitacheck/config/SecurityConfig.java
+++ b/src/main/java/com/vitacheck/config/SecurityConfig.java
@@ -20,6 +20,7 @@ public class SecurityConfig {
 
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final JwtUtil jwtUtil;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private static final String[] SWAGGER_URL_ARRAY = {
             "/swagger-ui/**",
             "/v3/api-docs/**",
@@ -33,6 +34,8 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception ->
+                        exception.authenticationEntryPoint(customAuthenticationEntryPoint)) // 인증 실패시 해당 클래스가 동작
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/oauth2/**", "/login/**", "/error").permitAll()
                         .requestMatchers("/api/v1/auth/**").permitAll()

--- a/src/main/java/com/vitacheck/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/vitacheck/config/jwt/JwtAuthenticationFilter.java
@@ -13,7 +13,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.security.Security;
 import java.util.Collections;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/vitacheck/config/jwt/JwtUtil.java
+++ b/src/main/java/com/vitacheck/config/jwt/JwtUtil.java
@@ -40,7 +40,6 @@ public class JwtUtil {
     private String createToken(String email, long expirationTime) {
         Claims claims = Jwts.claims();
         claims.put("email", email);
-
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(new Date(System.currentTimeMillis()))

--- a/src/main/java/com/vitacheck/controller/UserController.java
+++ b/src/main/java/com/vitacheck/controller/UserController.java
@@ -2,12 +2,19 @@ package com.vitacheck.controller;
 
 import com.vitacheck.dto.UserDto;
 import com.vitacheck.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "user", description = "사용자 정보 관련 API")
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -15,6 +22,13 @@ public class UserController {
 
     private final UserService userService;
 
+    @Operation(summary = "내 정보 조회", description = "인증된 사용자의 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = UserDto.InfoResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content)
+    })
     @GetMapping("/me")
     public ResponseEntity<UserDto.InfoResponse> getMyInfo(@AuthenticationPrincipal UserDetails userDetails){
         String email = userDetails.getUsername();
@@ -22,6 +36,13 @@ public class UserController {
         return ResponseEntity.ok(myInfo);
     }
 
+    @Operation(summary = "내 정보 수정", description = "사용자의 닉네임을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = UserDto.InfoResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content)
+    })
     @PutMapping("/me")
     public ResponseEntity<UserDto.InfoResponse> updateMyInfo(
             @AuthenticationPrincipal UserDetails userDetails,


### PR DESCRIPTION
Close #12 

## 📝 작업 내용

Springdoc OpenAPI 어노테이션을 사용하여 `UserController`에 있는 사용자 관련 API(내 정보 조회/수정)의 명세를 작성했습니다.

이를 통해 프론트엔드 개발자 및 다른 팀원들이 Swagger UI에서 API의 기능, 요청/응답 형식 등을 명확히 확인하고 직접 테스트까지 해볼 수 있게 되었습니다.

## ✅ 변경 사항

- [x] `UserController` 클래스에 `@Tag(name = "User", ...)`를 추가하여 API를 "User"로 그룹화했습니다.
- [x] `GET /api/v1/users/me` API에 `@Operation`으로 요약/상세 설명을 추가하고, `@ApiResponses`로 성공(200) 및 실패(401, 404) 케이스를 명세에 정의했습니다.
- [x] `PUT /api/v1/users/me` API에 `@Operation` 및 `@ApiResponses`를 추가하고, `@RequestBody`에 대한 명세가 자동 생성되도록 했습니다.
- [x] 인증이 안된 상태로 정보 조회를 시도했을 때 401 에러와 함께 인증이 필요하다는 메세지를 전달하는 커스텀 엔트리 포인트를 추가했습니다. 

## 💬 리뷰어에게

API 명세에 작성된 설명(`summary`, `description`)이 다른 팀원들이 보기에 명확하고 충분한지 검토 부탁드립니다.

혹시 더 추가되거나 수정되면 좋을 내용이 있다면 편하게 코멘트 남겨주세요!