### PR TITLE
refactor(#16): Erd에 맞춰 User 엔티티 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/vitacheck/VitacheckBeApplication.java
+++ b/src/main/java/com/vitacheck/VitacheckBeApplication.java
@@ -2,8 +2,10 @@ package com.vitacheck;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing // Auditing 기능 활성화
 public class VitacheckBeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/vitacheck/domain/BaseTimeEntity.java
+++ b/src/main/java/com/vitacheck/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.vitacheck.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class) // Auditing 기능 적용
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/vitacheck/domain/user/User.java
+++ b/src/main/java/com/vitacheck/domain/user/User.java
@@ -1,14 +1,18 @@
 package com.vitacheck.domain.user;
 
+import com.vitacheck.domain.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
+@Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class User {
+public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -23,9 +27,21 @@ public class User {
     private String providerId; // 소셜 로그인 서비스 고유 ID
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status;
+
+    private LocalDateTime lastLoginAt;
+
+    @Enumerated(EnumType.STRING)
     private Role role;
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public User updateFromSocial(String nickname) {
+        this.nickname = nickname;
+        this.lastLoginAt = LocalDateTime.now();
+        return this;
     }
 }

--- a/src/main/java/com/vitacheck/domain/user/UserStatus.java
+++ b/src/main/java/com/vitacheck/domain/user/UserStatus.java
@@ -1,0 +1,5 @@
+package com.vitacheck.domain.user;
+
+public enum UserStatus {
+    ACTIVE, INACTIVE, DELETED
+}

--- a/src/main/java/com/vitacheck/dto/OAuthAttributes.java
+++ b/src/main/java/com/vitacheck/dto/OAuthAttributes.java
@@ -2,11 +2,13 @@ package com.vitacheck.dto;
 
 import com.vitacheck.domain.user.Role;
 import com.vitacheck.domain.user.User;
+import com.vitacheck.domain.user.UserStatus;
 import com.vitacheck.util.RandomNicknameGenerator;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @Slf4j
@@ -110,6 +112,8 @@ public class OAuthAttributes {
                 .email(email)
                 .provider(provider)
                 .providerId(providerId)
+                .status(UserStatus.ACTIVE)
+                .lastLoginAt(LocalDateTime.now())
                 .role(Role.USER) // 기본 권한은 USER
                 .build();
     }

--- a/src/main/java/com/vitacheck/dto/UserDto.java
+++ b/src/main/java/com/vitacheck/dto/UserDto.java
@@ -16,5 +16,6 @@ public class UserDto {
     public static class InfoResponse {
         private String email;
         private String nickname;
+        private String provider;
     }
 }

--- a/src/main/java/com/vitacheck/service/UserService.java
+++ b/src/main/java/com/vitacheck/service/UserService.java
@@ -18,7 +18,7 @@ public class UserService {
     public UserDto.InfoResponse getMyInfo(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
-        return new UserDto.InfoResponse(user.getEmail(), user.getNickname());
+        return new UserDto.InfoResponse(user.getEmail(), user.getNickname(), user.getProvider());
     }
 
     @Transactional
@@ -26,6 +26,6 @@ public class UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
         user.updateNickname(request.getNickname());
-        return new UserDto.InfoResponse(user.getEmail(), user.getNickname());
+        return new UserDto.InfoResponse(user.getEmail(), user.getNickname(), user.getProvider());
     }
 }


### PR DESCRIPTION
Close #16 

## 📝 작업 내용

기존의 소셜 로그인 기반 `User` 모델과, 팀에서 새롭게 정의한 ERD의 상세한 `users` 테이블 스키마를 통합하는 리팩토링을 진행했습니다.

이 작업을 통해 `provider`, `providerId`를 포함한 소셜 로그인 정보를 유지하면서, `status`, `lastLoginAt`, `createdAt`, `updatedAt` 등 회원 관리를 위한 상세 정보를 추가하여 더 확장성 있고 안정적인 사용자 데이터 모델을 구축했습니다.

## ✅ 변경 사항

### **1. JPA Auditing 설정 (시간 자동 기록)**
- **`BaseTimeEntity`**: `createdAt`, `updatedAt` 필드를 자동으로 관리하기 위한 `BaseTimeEntity` 추상 클래스를 추가했습니다.
- **`@EnableJpaAuditing`**: 메인 애플리케이션에 해당 어노테이션을 추가하여 JPA Auditing 기능을 활성화했습니다.

### **2. User 도메인 모델 수정**
- **`UserStatus` Enum**: 기존 `Role`을 대체하여 `ACTIVE`, `INACTIVE`, `DELETED` 상태를 관리하는 `UserStatus` Enum을 추가했습니다.
- **`User` 엔티티**:
    - `BaseTimeEntity`를 상속받도록 변경했습니다.
    - ERD에 맞춰 `status`, `lastLoginAt` 필드를 추가했습니다.
    - 기존 소셜 로그인 기능을 위해 `provider`, `providerId` 필드는 유지했습니다.
    - 기존 사용자가 다시 로그인할 때 정보를 업데이트하는 `updateFromSocial` 메소드를 추가했습니다.
- **`UserRepository`**:
    - 소셜 로그인 사용자를 고유하게 식별하기 위해 `findByProviderAndProviderId` 메소드를 사용하도록 로직을 통일했습니다.

### **3. 비즈니스 로직 수정**
- **`OAuthAttributes`**:
    - 신규 사용자 생성(`toEntity`) 시, 새로운 필드(`status`, `lastLoginAt` 등)가 모두 포함되도록 수정했습니다.
- **`OAuth2SuccessHandler`**:
    - `findByProviderAndProviderId`를 사용하여 사용자를 조회하도록 변경했습니다.
    - 이미 가입된 사용자의 경우, `.map()`을 통해 `updateFromSocial()` 메소드를 호출하여 닉네임과 마지막 로그인 시간을 업데이트하도록 수정했습니다.
    - 신규 사용자의 경우, `.orElseGet()`을 통해 `attributes.toEntity()`를 호출하여 생성하도록 로직을 유지했습니다.
