### PR TITLE
feat(#18): 식약처 api 초기설정 및 테스트 컨트롤러 구현

### DIFF
--- a/src/main/java/com/vitacheck/config/RestTemplateConfig.java
+++ b/src/main/java/com/vitacheck/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.vitacheck.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    // 외부 API 쉽게 호출하기 위한 RestTemplate 생성
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/vitacheck/controller/TestController.java
+++ b/src/main/java/com/vitacheck/controller/TestController.java
@@ -1,0 +1,40 @@
+package com.vitacheck.controller;
+
+import com.vitacheck.dto.FoodSafetyApiResponseDto;
+import com.vitacheck.service.FoodSafetyApiService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TestController {
+
+    private final FoodSafetyApiService foodSafetyApiService;
+
+    @Operation(summary = "원료인정번호로 영양제 검색", description = "식품안전나라 API를 이용해 원료인정번호로 영양제 정보를 검색합니다.")
+    @GetMapping("/search-by-recognition-no")
+    public ResponseEntity<List<FoodSafetyApiResponseDto.SupplementInfo>> searchByRecognitionNo(
+            @Parameter(description = "검색할 원료인정번호", required = true, example = "제2012-36호") // 예시 값 수정
+            @RequestParam("recognitionNo") String recognitionNo
+    ) {
+        List<FoodSafetyApiResponseDto.SupplementInfo> results = foodSafetyApiService.searchSupplementsByRecognitionNo(recognitionNo);
+        return ResponseEntity.ok(results);
+    }
+
+    @Operation(summary = "원재료명으로 영양제 검색", description = "식품안전나라 API를 이용해 원재료명으로 영양제 정보를 검색합니다.")
+    @GetMapping("/search-by-raw-material")
+    public ResponseEntity<List<FoodSafetyApiResponseDto.SupplementInfo>> searchByRawMaterial(
+            @Parameter(description = "검색할 원재료명", required = true, example = "핑거루트추출분말") // 예시 값 수정
+            @RequestParam("rawMaterial") String rawMaterial
+    ) {
+        List<FoodSafetyApiResponseDto.SupplementInfo> results = foodSafetyApiService.searchSupplementsByRawMaterial(rawMaterial);
+        return ResponseEntity.ok(results);
+    }
+}

--- a/src/main/java/com/vitacheck/dto/FoodSafetyApiResponseDto.java
+++ b/src/main/java/com/vitacheck/dto/FoodSafetyApiResponseDto.java
@@ -1,0 +1,64 @@
+package com.vitacheck.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class FoodSafetyApiResponseDto {
+
+    @JsonProperty("C003")
+    private C003 c003;
+
+    @Getter
+    @ToString
+    public static class C003 {
+        @JsonProperty("total_count")
+        private String totalCount;
+
+        @JsonProperty("row")
+        private List<SupplementInfo> supplements;
+
+        @JsonProperty("RESULT")
+        private Result result;
+    }
+
+    @Getter
+    @ToString
+    public static class SupplementInfo {
+
+        @JsonProperty("PRIMARY_FNCLTY")
+        private String primaryFunction; // 주된 기능성
+
+        @JsonProperty("HF_FNCLTY_MTRAL_RCOGN_NO")
+        private String functionalMaterialRecognitionNo; // 원료인정번호
+
+        @JsonProperty("DAY_INTK_HIGHLIMIT")
+        private String dayIntakeHighLimit; // 1일 섭취량 상한선
+
+        @JsonProperty("DAY_INTK_LOWLIMIT")
+        private String dayIntakeLowLimit; // 1일 섭취량 하한선
+
+        @JsonProperty("WT_UNIT")
+        private String weightUnit; // 중량 단위
+
+        @JsonProperty("RAWMTRL_NM")
+        private String rawMaterialName; // 원재료 명
+
+        @JsonProperty("IFTKN_ATNT_MATR_CN")
+        private String intakeCaution; // 섭취시 주의 사항 내용
+    }
+
+    @Getter
+    @ToString
+    public static class Result {
+        @JsonProperty("MSG")
+        private String message;
+
+        @JsonProperty("CODE")
+        private String code;
+    }
+}

--- a/src/main/java/com/vitacheck/service/FoodSafetyApiService.java
+++ b/src/main/java/com/vitacheck/service/FoodSafetyApiService.java
@@ -1,0 +1,80 @@
+package com.vitacheck.service;
+
+import com.vitacheck.dto.FoodSafetyApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FoodSafetyApiService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${open-api.food-safety-korea.api-key}")
+    private String apiKey;
+
+    private final String API_BASE_URL = "http://openapi.foodsafetykorea.go.kr/api";
+    private final String SERVICE_ID = "C003";
+    private final String DATA_TYPE = "json";
+
+    /**
+     * 원료인정번호로 영양제 정보를 검색합니다.
+     * @param recognitionNo 검색할 원료인정번호
+     * @return 검색 결과 리스트
+     */
+    public List<FoodSafetyApiResponseDto.SupplementInfo> searchSupplementsByRecognitionNo(String recognitionNo) {
+        log.info("식품안전나라 API 호출 시작: 원료인정번호 = {}", recognitionNo);
+        return callApi("HF_FNCLTY_MTRAL_RCOGN_NO", recognitionNo);
+    }
+
+    /**
+     * 원재료명으로 영양제 정보를 검색합니다.
+     * @param rawMaterialName 검색할 원재료명
+     * @return 검색 결과 리스트
+     */
+    public List<FoodSafetyApiResponseDto.SupplementInfo> searchSupplementsByRawMaterial(String rawMaterialName) {
+        log.info("식품안전나라 API 호출 시작: 원재료명 = {}", rawMaterialName);
+        return callApi("RAWMTRL_NM", rawMaterialName);
+    }
+
+    /**
+     * 식품안전나라 API를 호출하는 공통 메소드
+     * @param searchField API 요청 시 사용할 검색 필드명 (예: "PRDLST_NM")
+     * @param searchValue 검색할 값
+     * @return API 응답 결과 리스트
+     */
+    private List<FoodSafetyApiResponseDto.SupplementInfo> callApi(String searchField, String searchValue) {
+        int startIndex = 1;
+        int endIndex = 10; // 우선 10개만 가져오도록 설정
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(API_BASE_URL)
+                .pathSegment(apiKey, SERVICE_ID, DATA_TYPE, String.valueOf(startIndex), String.valueOf(endIndex))
+                .queryParam(searchField, searchValue)
+                .build()
+                .toUri();
+
+        try {
+            FoodSafetyApiResponseDto response = restTemplate.getForObject(uri, FoodSafetyApiResponseDto.class);
+            if (response != null && response.getC003() != null && response.getC003().getSupplements() != null) {
+                log.info("API 호출 성공: {}개의 결과를 찾았습니다.", response.getC003().getTotalCount());
+                return response.getC003().getSupplements();
+            } else {
+                log.warn("API 호출은 성공했으나, 유효한 데이터가 없습니다. 응답: {}", response);
+                return Collections.emptyList();
+            }
+        } catch (Exception e) {
+            log.error("식품안전나라 API 호출 중 에러 발생: {}", e.getMessage());
+            throw new RuntimeException("식품안전나라 API 호출에 실패했습니다.");
+        }
+    }
+}


### PR DESCRIPTION
Close #18 

## 📝 작업 내용

VitaCheck 서비스의 데이터 신뢰도와 풍부함을 확보하기 위해, **식품안전나라(foodsafetykorea.go.kr)에서 제공하는 '건강기능식품 품목별 정보' 공공데이터 API**를 연동했습니다.

이를 통해 우리 서버가 외부 API를 호출하여 영양제 제품의 상세 정보를 **원료인정번호, 원재료명** 등 다양한 조건으로 검색할 수 있는 기반을 마련했습니다.

## ✅ 변경 사항

- **`application-local.yml` 설정 추가**
    - `open-api.food-safety-korea.api-key` 항목을 추가하여 API 인증키를 안전하게 관리하도록 했습니다.

- **`RestTemplateConfig` 추가**
    - 외부 API 호출을 위한 `RestTemplate`을 Bean으로 등록하는 설정 파일을 추가했습니다.

- **`FoodSafetyApiResponseDto` 생성**
    - `dto.foodsafety` 패키지를 생성하고, 식품안전나라 API의 중첩된 JSON 응답 구조를 파싱하기 위한 DTO 클래스를 구현했습니다. [cite: food_safety_api_setup_v1]

- **`FoodSafetyApiService` 구현**
    - `RestTemplate`을 사용하여 실제 API를 호출하는 `FoodSafetyApiService`를 구현했습니다. [cite: food_safety_api_setup_v1]
    - API 호출 로직을 공통화하고, 아래의 두 가지 검색 메소드를 제공합니다.
        - `searchSupplementsByRecognitionNo(String recognitionNo)`
        - `searchSupplementsByRawMaterial(String rawMaterialName)`

- **`TestController` 추가**
    - `FoodSafetyApiService`의 검색 기능들을 외부에서 호출할 수 있도록, 아래의 API 엔드포인트를 포함하는 `SupplementController`를 추가했습니다. [cite: supplement_controller_v1]
        - `GET /api/v1/supplements/search-by-recognition-no`
        - `GET /api/v1/supplements/search-by-raw-material`
    - 각 API에 대한 Swagger 문서화 어노테이션을 추가하여 명세를 명확히 했습니다.

## 💬 리뷰어에게

외부 API를 호출하는 첫 기능입니다.

- `FoodSafetyApiService`의 `callApi` 메소드에서 `RestTemplate` 사용 방식과 예외 처리 로직이 적절한지
- `TestController`에 추가된 새로운 엔드포인트들의 경로와 파라미터가 RESTful 원칙에 맞는지

위 두 가지를 중점적으로 검토해주시면 감사하겠습니다. 이 기능이 머지되면, 프론트엔드에서 다양한 조건으로 영양제를 검색하는 기능을 구현할 수 있게 됩니다.
