### PR TITLE
feat(#19): response design

### DIFF
--- a/src/main/java/com/vitacheck/global/apiPayload/CustomException.java
+++ b/src/main/java/com/vitacheck/global/apiPayload/CustomException.java
@@ -1,0 +1,15 @@
+package com.vitacheck.global.apiPayload;
+
+import com.vitacheck.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+
+    private final BaseErrorCode code;
+
+    public CustomException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.code = errorCode;
+    }
+}

--- a/src/main/java/com/vitacheck/global/apiPayload/CustomResponse.java
+++ b/src/main/java/com/vitacheck/global/apiPayload/CustomResponse.java
@@ -1,0 +1,67 @@
+package com.vitacheck.global.apiPayload;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.vitacheck.global.apiPayload.code.BaseCode;
+import com.vitacheck.global.apiPayload.code.BaseErrorCode;
+import com.vitacheck.global.apiPayload.code.GeneralSuccessCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class CustomResponse<T> {
+
+    @JsonProperty("isSuccess") // isSuccess라는 변수라는 것을 명시하는 Annotation
+    private boolean isSuccess;
+
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("result")
+    private final T result;
+
+    // 200 OK
+    public static <T> CustomResponse<T> ok(T result) {
+        return CustomResponse.onSuccess(GeneralSuccessCode.OK, result);
+    }
+
+    // 201 CREATED
+    public static <T> CustomResponse<T> created(T result) {
+        return CustomResponse.onSuccess(GeneralSuccessCode.CREATED, result);
+    }
+
+    // 상태 코드 받아 응답하는 메서드
+    public static <T> CustomResponse<T> onSuccess(BaseCode code, T result) {
+        return new CustomResponse<>(
+                true,
+                code.getCode(),
+                code.getMessage(),
+                result
+        );
+    }
+
+    //실패 응답 생성 메서드 (데이터 포함)
+    public static <T> CustomResponse<T> onFailure(BaseErrorCode code, T result) {
+        return new CustomResponse<>(
+                false,
+                code.getCode(),
+                code.getMessage(),
+                result
+        );
+    }
+
+    //실패 응답 생성 메서드 (데이터 없음)
+    public static <T> CustomResponse<T> onFailure(BaseErrorCode code) {
+        return new CustomResponse<>(
+                false,
+                code.getCode(),
+                code.getMessage(),
+                null
+        );
+    }
+}

--- a/src/main/java/com/vitacheck/global/apiPayload/GlobalExceptionHandler.java
+++ b/src/main/java/com/vitacheck/global/apiPayload/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.vitacheck.global.apiPayload;
+import lombok.extern.slf4j.Slf4j;
+import com.vitacheck.global.apiPayload.code.BaseErrorCode;
+import com.vitacheck.global.apiPayload.code.GeneralErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 애플리케이션에서 발생하는 커스텀 예외를 처리
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<CustomResponse<Void>> handleCustomException(
+            CustomException ex
+    ) {
+        //예외가 발생하면 로그 기록
+        log.warn("[ CustomException ]: {}", ex.getCode().getMessage());
+        //커스텀 예외에 정의된 에러 코드와 메시지를 포함한 응답 제공
+        return ResponseEntity.status(ex.getCode().getHttpStatus())
+                .body(CustomResponse.onFailure(
+                                ex.getCode(),
+                                null
+                        )
+                );
+    }
+
+
+    // 그 외의 정의되지 않은 모든 예외 처리
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<CustomResponse<String>> handleAllException(
+            Exception ex
+    ) {
+        log.error("[WARNING] Internal Server Error : {} ", ex.getMessage());
+        BaseErrorCode errorCode = GeneralErrorCode.INTERNAL_SERVER_ERROR_500;
+        CustomResponse<String> errorResponse = CustomResponse.onFailure(
+                errorCode,
+                null
+        );
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(errorResponse);
+    }
+
+}

--- a/src/main/java/com/vitacheck/global/apiPayload/code/BaseCode.java
+++ b/src/main/java/com/vitacheck/global/apiPayload/code/BaseCode.java
@@ -1,0 +1,9 @@
+package com.vitacheck.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/vitacheck/global/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/vitacheck/global/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,9 @@
+package com.vitacheck.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/vitacheck/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/vitacheck/global/apiPayload/code/GeneralErrorCode.java
@@ -1,0 +1,29 @@
+package com.vitacheck.global.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GeneralErrorCode implements BaseErrorCode{
+
+    BAD_REQUEST_400(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다"),
+
+    UNAUTHORIZED_401(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다"),
+
+    FORBIDDEN_403(HttpStatus.FORBIDDEN, "COMMON403", "접근이 금지되었습니다"),
+
+    NOT_FOUND_404(HttpStatus.NOT_FOUND, "COMMON404", "요청한 자원을 찾을 수 없습니다"),
+
+    INTERNAL_SERVER_ERROR_500(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 내부 오류가 발생했습니다"),
+
+    // 유효성 검사
+    VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALID400_0", "잘못된 파라미터 입니다.")
+    ;
+
+    // 필요한 필드값 선언
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/vitacheck/global/apiPayload/code/GeneralSuccessCode.java
+++ b/src/main/java/com/vitacheck/global/apiPayload/code/GeneralSuccessCode.java
@@ -1,0 +1,21 @@
+package com.vitacheck.global.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GeneralSuccessCode implements BaseCode{
+
+    OK(HttpStatus.OK,
+            "COMMON200",
+            "성공적으로 요청을 수행했습니다."),
+    CREATED(HttpStatus.CREATED,
+            "COMMON201",
+            "성공적으로 객체를 생성했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
Close #19 
modify #27 

## ## 📝 작업 내용
공통 응답 처리 기능 추가
공통 예외처리 수정
## ## ✅ 변경 사항
- [x] 공통 응답 처리 코드 추가
- [x] 공통 예외처리 수정 (합치는 과정에서 변수명과 파일명이 조금 바뀌었습니다.)


## ## 📷 스크린샷 (선택)
<img width="392" alt="image" src="https://github.com/user-attachments/assets/c8dd4382-c26b-4bf9-ac28-17ba8c94903f" />

응답은 위의 양식으로 통일했습니다. {"isSuccess", "code","message","result"}
성공했을 때, 작동하는 것을 swagger에서 확인했습니다. 

## ## 💬 리뷰어에게
CustomResponse<>로 불러와야 공통 응답을 사용할 수 있습니다. 
예외 처리는 controller 완성 후 공통된 응답으로 답하는지 다시 확인 필요합니다. 