### PR TITLE
feat(#44): 자체 회원가입 추가 및 기존 로직 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     implementation('com.amazonaws:aws-java-sdk-s3:1.12.600') {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
+
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4' // 혹은 최신 안정 버전
 }
 
 tasks.named('test') {

--- a/src/main/java/com/vitacheck/config/SecurityConfig.java
+++ b/src/main/java/com/vitacheck/config/SecurityConfig.java
@@ -10,6 +10,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -26,6 +28,9 @@ public class SecurityConfig {
             // Swagger UI v3
             "/v3/api-docs/**",
             "/swagger-ui/**",
+            // login, signup
+            "/api/v1/auth/signup",
+            "/api/v1/auth/login",
             // OAuth2
             "/",
             "/login/**",
@@ -33,6 +38,11 @@ public class SecurityConfig {
             // 기타
             "/error"
     };
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/vitacheck/controller/AuthController.java
+++ b/src/main/java/com/vitacheck/controller/AuthController.java
@@ -1,0 +1,60 @@
+package com.vitacheck.controller;
+
+import com.vitacheck.dto.UserDto;
+import com.vitacheck.global.apiPayload.CustomResponse;
+import com.vitacheck.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Authentication", description = "사용자 인증 API (자체/소셜)")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserService userService;
+
+    @Operation(summary = "자체 회원가입", description = "이메일, 비밀번호 및 사용자 추가 정보를 이용해 가입을 요청합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @ApiResponse(responseCode = "400", description = "입력 값 형식 오류 또는 이메일 중복", content = @Content)
+    })
+    @PostMapping("/signup")
+    public CustomResponse<String> signUp(@RequestBody UserDto.SignUpRequest request) {
+        userService.signUp(request);
+        return CustomResponse.created("회원가입이 성공적으로 완료되었습니다.");
+    }
+
+    @Operation(summary = "자체 로그인", description = "이메일과 비밀번호로 로그인하고 API 접근을 위한 JWT를 발급받습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class))),
+            @ApiResponse(responseCode = "404", description = "가입되지 않은 회원이거나 비밀번호가 틀린 경우", content = @Content)
+    })
+    @PostMapping("/login")
+    public CustomResponse<UserDto.TokenResponse> login(@RequestBody UserDto.LoginRequest request) {
+        UserDto.TokenResponse tokenResponse = userService.login(request);
+        return CustomResponse.ok(tokenResponse);
+    }
+
+    @Operation(summary = "소셜 회원가입", description = "소셜 로그인 후 추가 정보를 받아 최종 회원가입을 처리하고 JWT를 발급합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "소셜 회원가입 및 로그인 성공",
+                    content = @Content(schema = @Schema(implementation = CustomResponse.class))),
+            @ApiResponse(responseCode = "400", description = "이미 가입된 회원이거나 필수 입력값이 누락된 경우", content = @Content)
+    })
+    @PostMapping("/social-signup")
+    public CustomResponse<UserDto.TokenResponse> socialSignUp(@RequestBody UserDto.SocialSignUpRequest request) {
+        UserDto.TokenResponse tokenResponse = userService.socialSignUp(request);
+        return CustomResponse.ok(tokenResponse);
+    }
+}

--- a/src/main/java/com/vitacheck/domain/user/Gender.java
+++ b/src/main/java/com/vitacheck/domain/user/Gender.java
@@ -1,0 +1,5 @@
+package com.vitacheck.domain.user;
+
+public enum Gender {
+    MALE, FEMALE, NONE
+}

--- a/src/main/java/com/vitacheck/domain/user/User.java
+++ b/src/main/java/com/vitacheck/domain/user/User.java
@@ -4,6 +4,7 @@ import com.vitacheck.domain.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -20,10 +21,28 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false, unique = true)
     private String email;
 
+    private String password;
+
+    @Column(nullable = false, name = "full_name", length = 100)
+    private String fullName;
+
     @Column(nullable = false)
     private String nickname;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Gender gender;
+
+    @Column(nullable = false, name = "birth_date")
+    private LocalDate birthDate;
+
+    @Column(name = "phone_number", nullable = false, length = 20)
+    private String phoneNumber;
+
+    @Column(nullable = false, length = 20)
     private String provider; // 예: google, kakao
+
+    @Column(name = "provider_id", length = 100)
     private String providerId; // 소셜 로그인 서비스 고유 ID
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/vitacheck/dto/OAuthAttributes.java
+++ b/src/main/java/com/vitacheck/dto/OAuthAttributes.java
@@ -37,9 +37,6 @@ public class OAuthAttributes {
         if ("naver".equals(registrationId)) {
             return ofNaver("id", attributes);
         }
-        if ("kakao".equals(registrationId)) {
-            return ofKakao("id", attributes);
-        }
         return ofGoogle(userNameAttributeName, attributes);
     }
 
@@ -49,31 +46,6 @@ public class OAuthAttributes {
                 .email((String) attributes.get("email"))
                 .provider("google")
                 .providerId((String) attributes.get("sub"))
-                .attributes(attributes)
-                .nameAttributeKey(userNameAttributeName)
-                .build();
-    }
-
-    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
-        // Kakao는 응답이 중첩된 JSON 구조이므로, 필요한 정보를 꺼내야 합니다.
-        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
-        String providerId = String.valueOf(attributes.get("id"));
-
-        String email = null;
-        if (kakaoAccount != null) {
-            email = (String) kakaoAccount.get("email");
-        }
-        // 가상 이메일 생성
-        if (email == null || email.isBlank()) {
-            email = providerId + "@kakao.com";
-        }
-
-        return OAuthAttributes.builder()
-                .name((String) kakaoProfile.get("nickname"))
-                .email(email)
-                .provider("kakao")
-                .providerId(providerId)
                 .attributes(attributes)
                 .nameAttributeKey(userNameAttributeName)
                 .build();

--- a/src/main/java/com/vitacheck/dto/UserDto.java
+++ b/src/main/java/com/vitacheck/dto/UserDto.java
@@ -1,10 +1,82 @@
 package com.vitacheck.dto;
 
+import com.vitacheck.domain.user.Gender;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 public class UserDto {
+
+    // 자체 회원가입 요청 DTO
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "자체 회원가입 요청 DTO")
+    public static class SignUpRequest {
+        @Schema(description = "사용자 이메일 주소", example = "user@vitacheck.com")
+        private String email;
+
+        @Schema(description = "사용자 비밀번호 (8자 이상)", example = "password123!")
+        private String password;
+
+        @Schema(description = "사용자 실명", example = "홍길동")
+        private String fullName;
+
+        @Schema(description = "사용할 닉네임", example = "행복한쿼카")
+        private String nickname;
+
+        @Schema(description = "성별", example = "MALE")
+        private Gender gender;
+
+        @Schema(description = "생년월일", example = "2000-01-01")
+        private LocalDate birthDate;
+
+        @Schema(description = "휴대폰 번호", example = "010-1234-5678")
+        private String phoneNumber;
+    }
+
+    // 자체 로그인 요청 DTO
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "자체 로그인 요청 DTO")
+    public static class LoginRequest {
+        @Schema(description = "이메일 주소", example = "user@vitacheck.com")
+        private String email;
+
+        @Schema(description = "비밀번호", example = "password123!")
+        private String password;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class SocialSignUpRequest {
+        // 소셜 로그인 제공 정보
+        private String email;
+        private String fullName;
+        private String provider;
+        private String providerId;
+
+        // 사용자가 직접 입력한 정보
+        private String nickname;
+        private Gender gender;
+        private LocalDate birthDate;
+        private String phoneNumber;
+    }
+
+    // JWT 토큰 응답 DTO
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "로그인 성공 시 JWT 토큰 응답 DTO")
+    public static class TokenResponse {
+        @Schema(description = "API 접근을 위한 Access Token")
+        private String accessToken;
+
+        @Schema(description = "Access Token 재발급을 위한 Refresh Token")
+        private String refreshToken;
+    }
+
     @Getter
     @NoArgsConstructor
     public static class UpdateRequest {
@@ -16,6 +88,7 @@ public class UserDto {
     public static class InfoResponse {
         private String email;
         private String nickname;
+        private String fullName;
         private String provider;
     }
 }

--- a/src/main/java/com/vitacheck/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/vitacheck/global/apiPayload/code/ErrorCode.java
@@ -13,6 +13,8 @@ public enum ErrorCode implements BaseErrorCode {
     // 유저
     UNAUTHORIZED("U0001", "로그인이 필요합니다.", HttpStatus.UNAUTHORIZED),
     USER_NOT_FOUND("U0002", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    DUPLICATED_EMAIL("U0003", "이미 사용 중인 이메일입니다.", HttpStatus.BAD_REQUEST),
+    PASSWORD_NOT_MATCH("U0004", "비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
 
     // 영양제
     SUPPLEMENT_NOT_FOUND("S0001", "영양제를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/vitacheck/service/UserService.java
+++ b/src/main/java/com/vitacheck/service/UserService.java
@@ -1,13 +1,19 @@
 package com.vitacheck.service;
 
+import com.vitacheck.config.jwt.JwtUtil;
+import com.vitacheck.domain.user.Role;
 import com.vitacheck.domain.user.User;
+import com.vitacheck.domain.user.UserStatus;
 import com.vitacheck.dto.UserDto;
 import com.vitacheck.global.apiPayload.CustomException;
 import com.vitacheck.global.apiPayload.code.ErrorCode;
 import com.vitacheck.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
 
 @Service
 @Transactional(readOnly = true)
@@ -15,11 +21,78 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    @Transactional
+    public void signUp(UserDto.SignUpRequest request) {
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new CustomException(ErrorCode.DUPLICATED_EMAIL);
+        }
+
+        User newUser = User.builder()
+                .email(request.getEmail())
+                .password(passwordEncoder.encode(request.getPassword())) // 비밀번호는 반드시 암호화하여 저장
+                .fullName(request.getFullName())
+                .nickname(request.getNickname())
+                .gender(request.getGender())
+                .birthDate(request.getBirthDate())
+                .phoneNumber(request.getPhoneNumber())
+                .role(Role.USER)
+                .status(UserStatus.ACTIVE)
+                .provider("vitacheck") // 자체 회원가입 사용자를 명시
+                .lastLoginAt(LocalDateTime.now())
+                .build();
+        userRepository.save(newUser);
+    }
+
+    public UserDto.TokenResponse login(UserDto.LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getPassword() == null || !passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new CustomException(ErrorCode.PASSWORD_NOT_MATCH);
+        }
+
+        String accessToken = jwtUtil.createAccessToken(user.getEmail());
+        String refreshToken = jwtUtil.createRefreshToken(user.getEmail());
+
+        return new UserDto.TokenResponse(accessToken, refreshToken);
+    }
+
+    @Transactional
+    public UserDto.TokenResponse socialSignUp(UserDto.SocialSignUpRequest request) {
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new CustomException(ErrorCode.DUPLICATED_EMAIL);
+        }
+
+        User newUser = User.builder()
+                .email(request.getEmail())
+                // 소셜 로그인은 비밀번호가 없으므로 password 필드는 null
+                .fullName(request.getFullName())
+                .nickname(request.getNickname())
+                .gender(request.getGender())
+                .birthDate(request.getBirthDate())
+                .phoneNumber(request.getPhoneNumber())
+                .provider(request.getProvider())
+                .providerId(request.getProviderId())
+                .role(Role.USER)
+                .status(UserStatus.ACTIVE)
+                .lastLoginAt(LocalDateTime.now())
+                .build();
+
+        userRepository.save(newUser);
+
+        String accessToken = jwtUtil.createAccessToken(newUser.getEmail());
+        String refreshToken = jwtUtil.createRefreshToken(newUser.getEmail());
+
+        return new UserDto.TokenResponse(accessToken, refreshToken);
+    }
 
     public UserDto.InfoResponse getMyInfo(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        return new UserDto.InfoResponse(user.getEmail(), user.getNickname(), user.getProvider());
+        return new UserDto.InfoResponse(user.getEmail(), user.getNickname(), user.getFullName(), user.getProvider());
     }
 
     @Transactional
@@ -27,7 +100,7 @@ public class UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         user.updateNickname(request.getNickname());
-        return new UserDto.InfoResponse(user.getEmail(), user.getNickname(), user.getProvider());
+        return new UserDto.InfoResponse(user.getEmail(), user.getNickname(), user.getFullName(), user.getProvider());
     }
 
     public Long findIdByEmail(String email) {

--- a/src/main/resources/application-local.yml.example
+++ b/src/main/resources/application-local.yml.example
@@ -18,15 +18,6 @@ spring:
             scope:
               - email
               - profile
-          kakao:
-            client-id: # 카카오 디벨로퍼스에서 발급받은 REST API 키
-            client-secret: # 카카오 디벨로퍼스에서 발급받은 Client Secret
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
-            client-authentication-method: client_secret_post
-            authorization-grant-type: authorization_code
-            scope:
-              - profile_nickname
-            client-name: Kakao
           naver:
             client-id: # 네이버 개발자 센터에서 발급받은 Client ID
             client-secret: # 네이버 개발자 센터에서 발급받은 Client Secret
@@ -40,11 +31,6 @@ spring:
 
         provider:
           # Google은 Spring Boot가 자동 설정해주므로 생략 가능
-          kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
-            user-name-attribute: id
           naver:
             authorization-uri: https://nid.naver.com/oauth2.0/authorize
             token-uri: https://nid.naver.com/oauth2.0/token
@@ -63,3 +49,16 @@ jwt:
 open-api:
   food-safety-korea:
     api-key: api 키
+
+# S3 관련 설정
+cloud:
+  aws:
+    credentials:
+      access-key: test-key
+      secret-key: test-secret
+    s3:
+      bucket: local-vitacheck
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,23 +22,12 @@ spring:
             client-id: "test-google-client-id"
             client-secret: "test-google-client-secret"
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}" # redirect-uri 추가
-          kakao:
-            client-id: "test-kakao-client-id"
-            client-secret: "test-kakao-client-secret"
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
-            authorization-grant-type: authorization_code
-            client-authentication-method: client_secret_post # kakao는 post 방식 사용
           naver:
             client-id: "test-naver-client-id"
             client-secret: "test-naver-client-secret"
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             authorization-grant-type: authorization_code
         provider: # 각 provider의 상세 정보 추가
-          kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
-            user-name-attribute: id
           naver:
             authorization-uri: https://nid.naver.com/oauth2.0/authorize
             token-uri: https://nid.naver.com/oauth2.0/token

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -56,11 +56,6 @@ spring:
           google:
             client-id: dummy-client-id
             client-secret: dummy-client-secret
-          kakao:
-            client-id: dummy-client-id
-            client-secret: dummy-client-secret
-            authorization-grant-type: authorization_code
-            client-authentication-method: client_secret_post
           naver:
             client-id: dummy-client-id
             client-secret: dummy-client-secret


### PR DESCRIPTION
Close #44 

## 📝 작업 내용
기존 소셜 로그인 중심의 인증 시스템을 대대적으로 개편하여, 새로운 ERD 스키마에 맞춘 자체 회원가입 및 로그인 기능을 추가했습니다. 또한, 모든 가입 경로에서 일관된 사용자 정보를 수집하도록 프로세스를 통합하고 코드의 안정성과 확장성을 개선했습니다.

## ✅ 변경 사항
[x] 자체 회원가입/로그인 기능 추가

이메일, 비밀번호 및 추가 정보(이름, 닉네임, 성별, 생년월일, 휴대폰 번호)를 이용한 자체 회원가입 기능을 구현했습니다.

이메일/비밀번호 기반의 자체 로그인 및 JWT 발급 기능을 구현했습니다.

인증 관련 API를 명확하게 관리하기 위해 AuthController를 신규 생성했습니다.

[x] User 엔티티 및 DTO 개편

새로운 ERD 스키마에 맞춰 User 엔티티를 수정했습니다. (필드 추가: fullName, password, gender, birthDate, phoneNumber)

SignUpRequest, LoginRequest, SocialSignUpRequest 등 인증 흐름에 맞는 DTO를 추가하고, @Schema 어노테이션을 통해 명세 가독성을 높였습니다.

[x] 소셜 로그인 프로세스 개선

신규 소셜 로그인 사용자는 인증 직후 추가 정보 입력 페이지로 리디렉션되도록 OAuth2SuccessHandler의 로직을 변경했습니다.

프론트엔드에서 추가 정보를 받아 최종 가입을 처리하는 social-signup API를 구현했습니다.

[x] 설정 및 의존성 정리

application-*.yml 파일에서 더 이상 사용하지 않는 카카오(Kakao) 관련 설정을 모두 제거했습니다.

로컬 개발 환경의 DB 설정을 Docker 기반의 로컬 MySQL을 바라보도록 수정하고, S3 설정은 테스트용 값으로 변경했습니다.

build.gradle에 누락되었던 AWS 관련 의존성을 추가하여 NoClassDefFoundError 오류를 해결했습니다.

[x] API 문서(Swagger) 보강

AuthController의 모든 API에 대해 @ApiResponses를 사용하여 발생 가능한 응답 코드(200, 201, 400, 404 등)와 그 의미를 상세히 명시했습니다.

## 💬 리뷰어에게
이번 PR은 인증 시스템의 핵심 로직을 크게 변경하는 작업이었습니다. 특히 신규 소셜 로그인 사용자의 리디렉션 처리와 자체 회원가입 로직을 중점적으로 리뷰해 주시면 감사하겠습니다.

또한, 로컬 개발 환경 설정을 개선했으므로, .env나 application-local.yml을 새로 설정해야 할 수 있습니다. 관련 내용은 README.md나 노션 페이지를 참고해 주세요. (필요 시 문서 업데이트 예정)