### PR TITLE
feat(#46): 내가 찜한 영양제 목록 조회 API 설계

### DIFF
--- a/src/main/java/com/vitacheck/controller/LikeRestController.java
+++ b/src/main/java/com/vitacheck/controller/LikeRestController.java
@@ -1,23 +1,26 @@
 package com.vitacheck.controller;
 
 import com.vitacheck.dto.LikeToggleResponseDto;
+import com.vitacheck.dto.LikedSupplementResponseDto;
 import com.vitacheck.global.apiPayload.CustomResponse;
 import com.vitacheck.service.LikeCommandService;
+import com.vitacheck.service.LikeQueryService;
 import com.vitacheck.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+@Tag(name = "likes", description = "사용자 찜 기능 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/supplements")
@@ -25,6 +28,7 @@ public class LikeRestController {
 
     private final LikeCommandService likeCommandService;
     private final UserService userService;
+    private final LikeQueryService likeQueryService;
 
     @Operation(summary = "영양제 찜하기", description = "사용자가 특정 영양제를 찜하거나, 이미 찜한 경우 찜을 해제합니다. (토글 방식)")
     @ApiResponses(value = {
@@ -43,5 +47,22 @@ public class LikeRestController {
 
         LikeToggleResponseDto responseDto = likeCommandService.toggleLike(supplementId, userId);
         return CustomResponse.ok(responseDto);
+    }
+
+    @GetMapping("/likes/me")
+    @Operation(summary = "내가 찜한 영양제 목록 조회", description = "JWT 인증 기반으로 사용자가 찜한 영양제 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = LikedSupplementResponseDto.class)))),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    })
+    public CustomResponse<List<LikedSupplementResponseDto>> getMyLikedSupplements(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String email = userDetails.getUsername();
+        Long userId = userService.findIdByEmail(email);
+
+        List<LikedSupplementResponseDto> likedSupplements = likeQueryService.getLikedSupplementsByUserId(userId);
+        return CustomResponse.ok(likedSupplements);
     }
 }

--- a/src/main/java/com/vitacheck/dto/LikedSupplementResponseDto.java
+++ b/src/main/java/com/vitacheck/dto/LikedSupplementResponseDto.java
@@ -1,0 +1,19 @@
+package com.vitacheck.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LikedSupplementResponseDto {
+
+    private Long supplementId;
+    private String name;
+    private String brandName;
+    private String imageUrl;
+    private Integer price;
+}

--- a/src/main/java/com/vitacheck/repository/LikeRepository.java
+++ b/src/main/java/com/vitacheck/repository/LikeRepository.java
@@ -4,8 +4,11 @@ import com.vitacheck.domain.Like;
 import com.vitacheck.domain.Supplement;
 import com.vitacheck.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
+import java.util.List;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
@@ -14,4 +17,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     Optional<Like> findByUserAndSupplement(User user, Supplement supplement);
 
+    @Query("SELECT l FROM Like l JOIN FETCH l.supplement s JOIN FETCH s.brand WHERE l.user.id = :userId")
+    List<Like> findAllByUserIdWithSupplement(@Param("userId") Long userId);
 }

--- a/src/main/java/com/vitacheck/service/LikeQueryService.java
+++ b/src/main/java/com/vitacheck/service/LikeQueryService.java
@@ -1,0 +1,30 @@
+package com.vitacheck.service;
+
+import com.vitacheck.domain.Like;
+import com.vitacheck.dto.LikedSupplementResponseDto;
+import com.vitacheck.repository.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LikeQueryService {
+
+    private final LikeRepository likeRepository;
+
+    public List<LikedSupplementResponseDto> getLikedSupplementsByUserId(Long userId) {
+        List<Like> likes = likeRepository.findAllByUserIdWithSupplement(userId);
+
+        return likes.stream()
+                .map(like -> LikedSupplementResponseDto.builder()
+                        .supplementId(like.getSupplement().getId())
+                        .name(like.getSupplement().getName())
+                        .brandName(like.getSupplement().getBrand().getName())
+                        .imageUrl(like.getSupplement().getImageUrl())
+                        .price(like.getSupplement().getPrice())
+                        .build())
+                .toList();
+    }
+}


### PR DESCRIPTION
Close #46 

## ## 📝 작업 내용
내가 찜한 영양제 목록 조회 API 구현

## ## ✅ 변경 사항
LikeRestController 추가 로직 구현
LikeCommandService 추가 로직 구현
LikesRepository 추가 로직 구현
LikeQueryService 새로 생성
Swagger 태그 설정 (@Tag 추가)
Jwt 인증 연동 (로그인 사용자 기반 조회)


## ## 📷 스크린샷 (선택)
<img width="1428" height="176" alt="image" src="https://github.com/user-attachments/assets/52003a2d-636e-486f-a0fd-21e27572c062" />

## ## 💬 리뷰어에게