### PR TITLE
feat(#48): 내 영양제 복용 루틴 등록 API 설계

### DIFF
--- a/src/main/java/com/vitacheck/controller/LikeController.java
+++ b/src/main/java/com/vitacheck/controller/LikeController.java
@@ -24,7 +24,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/supplements")
-public class LikeRestController {
+public class LikeController {
 
     private final LikeCommandService likeCommandService;
     private final UserService userService;

--- a/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
@@ -1,0 +1,42 @@
+package com.vitacheck.controller;
+
+import com.vitacheck.dto.RoutineRegisterRequestDto;
+import com.vitacheck.dto.RoutineRegisterResponseDto;
+import com.vitacheck.global.apiPayload.CustomResponse;
+import com.vitacheck.service.NotificationRoutineCommandService;
+import com.vitacheck.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+@Tag(name = "notification-routines", description = "복용 루틴 등록 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationRoutineController {
+
+    private final NotificationRoutineCommandService notificationRoutineCommandService;
+    private final UserService userService;
+
+    @PostMapping("/routines")
+    @Operation(summary = "복용 루틴 등록", description = "현재 로그인한 사용자의 영양제 복용 루틴을 등록합니다.")
+    public ResponseEntity<CustomResponse<RoutineRegisterResponseDto>> registerRoutine(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody @Valid RoutineRegisterRequestDto request
+    ) {
+        String email = userDetails.getUsername();
+        Long userId = userService.findIdByEmail(email);
+
+        RoutineRegisterResponseDto response = notificationRoutineCommandService.registerRoutine(userId, request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(CustomResponse.created(response));
+    }
+}

--- a/src/main/java/com/vitacheck/domain/NotificationRoutine.java
+++ b/src/main/java/com/vitacheck/domain/NotificationRoutine.java
@@ -1,0 +1,57 @@
+package com.vitacheck.domain;
+
+import com.vitacheck.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "notification_routines")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationRoutine extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "supplement_id", nullable = false)
+    private Supplement supplement;
+
+    @Column(name = "is_enabled", nullable = false)
+    private boolean isEnabled = true;
+
+    @OneToMany(mappedBy = "notificationRoutine", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoutineDay> routineDays = new ArrayList<>();
+
+    @OneToMany(mappedBy = "notificationRoutine", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoutineTime> routineTimes = new ArrayList<>();
+
+    @Builder
+    public NotificationRoutine(User user, Supplement supplement) {
+        this.user = user;
+        this.supplement = supplement;
+        this.isEnabled = true;
+    }
+
+    public void addRoutineDay(RoutineDay day) {
+        this.routineDays.add(day);
+        day.setNotificationRoutine(this);
+    }
+
+    public void addRoutineTime(RoutineTime time) {
+        this.routineTimes.add(time);
+        time.setNotificationRoutine(this);
+    }
+}
+

--- a/src/main/java/com/vitacheck/domain/RoutineDay.java
+++ b/src/main/java/com/vitacheck/domain/RoutineDay.java
@@ -1,0 +1,35 @@
+package com.vitacheck.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "routine_days")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoutineDay {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notification_routines_id", nullable = false)
+    private NotificationRoutine notificationRoutine;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week", nullable = false)
+    private RoutineDayOfWeek dayOfWeek;
+
+    public void setNotificationRoutine(NotificationRoutine routine) {
+        this.notificationRoutine = routine;
+    }
+
+    @Builder
+    public RoutineDay(RoutineDayOfWeek dayOfWeek) {
+        this.dayOfWeek = dayOfWeek;
+    }
+}

--- a/src/main/java/com/vitacheck/domain/RoutineDayOfWeek.java
+++ b/src/main/java/com/vitacheck/domain/RoutineDayOfWeek.java
@@ -1,0 +1,5 @@
+package com.vitacheck.domain;
+
+public enum RoutineDayOfWeek {
+    MON, TUE, WED, THU, FRI, SAT, SUN
+}

--- a/src/main/java/com/vitacheck/domain/RoutineTime.java
+++ b/src/main/java/com/vitacheck/domain/RoutineTime.java
@@ -1,0 +1,36 @@
+package com.vitacheck.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "routine_times")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoutineTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notification_routines_id", nullable = false)
+    private NotificationRoutine notificationRoutine;
+
+    @Column(name = "time", nullable = false)
+    private LocalTime time;
+
+    public void setNotificationRoutine(NotificationRoutine routine) {
+        this.notificationRoutine = routine;
+    }
+
+    @Builder
+    public RoutineTime(LocalTime time) {
+        this.time = time;
+    }
+}

--- a/src/main/java/com/vitacheck/dto/RoutineRegisterRequestDto.java
+++ b/src/main/java/com/vitacheck/dto/RoutineRegisterRequestDto.java
@@ -1,0 +1,28 @@
+package com.vitacheck.dto;
+
+import com.vitacheck.domain.RoutineDayOfWeek;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoutineRegisterRequestDto {
+
+    @Schema(description = "복용할 영양제 ID", example = "1")
+    private Long supplementId;
+
+    @NotEmpty
+    @Schema(description = "복용 요일 리스트 (Enum)", example = "[\"MON\", \"WED\", \"FRI\"]")
+    private List<RoutineDayOfWeek> daysOfWeek;
+
+    @NotEmpty
+    @Schema(description = "복용 시간 리스트", example = "[\"08:00\", \"20:00\"]")
+    private List<LocalTime> times;
+}

--- a/src/main/java/com/vitacheck/dto/RoutineRegisterResponseDto.java
+++ b/src/main/java/com/vitacheck/dto/RoutineRegisterResponseDto.java
@@ -1,0 +1,25 @@
+package com.vitacheck.dto;
+
+import com.vitacheck.domain.RoutineDayOfWeek;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoutineRegisterResponseDto {
+
+    private Long routineId;
+
+    private Long supplementId;
+
+    private List<RoutineDayOfWeek> daysOfWeek;
+
+    private List<LocalTime> times;
+}

--- a/src/main/java/com/vitacheck/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/vitacheck/global/apiPayload/code/ErrorCode.java
@@ -23,8 +23,10 @@ public enum ErrorCode implements BaseErrorCode {
     EXTERNAL_API_ERROR("A0001", "외부 API 호출에 실패했습니다.", HttpStatus.SERVICE_UNAVAILABLE),
 
     // AWS
-    S3_UPLOAD_ERROR("S30001", "S3 업로드에 실패했습니다.", HttpStatus.CONFLICT);
+    S3_UPLOAD_ERROR("S30001", "S3 업로드에 실패했습니다.", HttpStatus.CONFLICT),
 
+    // 복용 루틴
+    DUPLICATED_ROUTINE("R0001", "이미 등록된 복용 루틴입니다.", HttpStatus.CONFLICT);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/vitacheck/repository/NotificationRoutineRepository.java
+++ b/src/main/java/com/vitacheck/repository/NotificationRoutineRepository.java
@@ -1,0 +1,31 @@
+package com.vitacheck.repository;
+
+import com.vitacheck.domain.NotificationRoutine;
+import com.vitacheck.domain.RoutineDayOfWeek;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Repository
+public interface NotificationRoutineRepository extends JpaRepository<NotificationRoutine, Long> {
+
+    @Query("""
+        SELECT COUNT(r) > 0
+        FROM NotificationRoutine r
+        JOIN r.routineDays d
+        JOIN r.routineTimes t
+        WHERE r.user.id = :userId
+          AND r.supplement.id = :supplementId
+          AND d.dayOfWeek IN :days
+          AND t.time IN :times
+    """)
+    boolean existsDuplicateRoutine(
+            Long userId,
+            Long supplementId,
+            List<RoutineDayOfWeek> days,
+            List<LocalTime> times
+    );
+}

--- a/src/main/java/com/vitacheck/repository/RoutineDayRepository.java
+++ b/src/main/java/com/vitacheck/repository/RoutineDayRepository.java
@@ -1,0 +1,9 @@
+package com.vitacheck.repository;
+
+import com.vitacheck.domain.RoutineDay;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoutineDayRepository extends JpaRepository<RoutineDay, Long> {
+}

--- a/src/main/java/com/vitacheck/repository/RoutineTimeRepository.java
+++ b/src/main/java/com/vitacheck/repository/RoutineTimeRepository.java
@@ -1,0 +1,9 @@
+package com.vitacheck.repository;
+
+import com.vitacheck.domain.RoutineTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoutineTimeRepository extends JpaRepository<RoutineTime, Long> {
+}

--- a/src/main/java/com/vitacheck/service/NotificationRoutineCommandService.java
+++ b/src/main/java/com/vitacheck/service/NotificationRoutineCommandService.java
@@ -1,0 +1,86 @@
+package com.vitacheck.service;
+
+import com.amazonaws.services.kms.model.NotFoundException;
+import com.vitacheck.domain.*;
+import com.vitacheck.domain.user.User;
+import com.vitacheck.dto.RoutineRegisterRequestDto;
+import com.vitacheck.dto.RoutineRegisterResponseDto;
+import com.vitacheck.global.apiPayload.CustomException;
+import com.vitacheck.global.apiPayload.code.ErrorCode;
+import com.vitacheck.repository.NotificationRoutineRepository;
+import com.vitacheck.repository.SupplementRepository;
+import com.vitacheck.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationRoutineCommandService {
+
+    private final NotificationRoutineRepository notificationRoutineRepository;
+    private final SupplementRepository supplementRepository;
+    private final UserRepository userRepository; // 또는 AuthContext에서 가져오는 방식
+
+    public RoutineRegisterResponseDto registerRoutine(Long userId, RoutineRegisterRequestDto request) {
+
+        // 1. 중복 등록 검사
+        boolean isDuplicate = notificationRoutineRepository.existsDuplicateRoutine(
+                userId,
+                request.getSupplementId(),
+                request.getDaysOfWeek(),
+                request.getTimes()
+        );
+        if (isDuplicate) {
+            throw new CustomException(ErrorCode.DUPLICATED_ROUTINE);
+        }
+
+        // 2. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 3. 영양제 존재 여부 검증
+        Supplement supplement = supplementRepository.findById(request.getSupplementId())
+                .orElseThrow(() -> new CustomException(ErrorCode.SUPPLEMENT_NOT_FOUND));
+
+        // 4. 루틴 엔티티 생성
+        NotificationRoutine routine = NotificationRoutine.builder()
+                .user(user)
+                .supplement(supplement)
+                .build();
+
+        // 5. 요일 추가
+        for (RoutineDayOfWeek dayOfWeek : request.getDaysOfWeek()) {
+            RoutineDay day = RoutineDay.builder()
+                    .dayOfWeek(dayOfWeek)
+                    .build();
+            routine.addRoutineDay(day);
+        }
+
+        // 6. 시간 추가
+        for (LocalTime time : request.getTimes()) {
+            RoutineTime routineTime = RoutineTime.builder()
+                    .time(time)
+                    .build();
+            routine.addRoutineTime(routineTime);
+        }
+
+        // 7. 저장 (cascade로 하위 엔티티도 자동 저장)
+        NotificationRoutine saved = notificationRoutineRepository.save(routine);
+
+        // 8. 응답 DTO 반환
+        return RoutineRegisterResponseDto.builder()
+                .routineId(saved.getId())
+                .supplementId(saved.getSupplement().getId())
+                .daysOfWeek(saved.getRoutineDays().stream()
+                        .map(RoutineDay::getDayOfWeek)
+                        .toList())
+                .times(saved.getRoutineTimes().stream()
+                        .map(RoutineTime::getTime)
+                        .toList())
+                .build();
+    }
+}


### PR DESCRIPTION
Close #48 

## ## 📝 작업 내용
내 영양제 복용 루틴 등록 기능 구현
중복 루틴 등록 방지 로직 추가 (userId + supplementId + 요일 + 시간 기준)

## ## ✅ 변경 사항
DTO, Entity, Service, Repository, Controller 계층 개발 완료
Swagger 테스트용 예시 및 CustomException 처리 적용
복용 루틴 중복 에러코드 추가 완료

## ## 📷 스크린샷 (선택)
## ## 💬 리뷰어에게