### PR TITLE
feat(#51): 내 복용 루틴 목록 조회 API 설계

### DIFF
--- a/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
@@ -2,10 +2,14 @@ package com.vitacheck.controller;
 
 import com.vitacheck.dto.RoutineRegisterRequestDto;
 import com.vitacheck.dto.RoutineRegisterResponseDto;
+import com.vitacheck.dto.RoutineResponseDto;
 import com.vitacheck.global.apiPayload.CustomResponse;
 import com.vitacheck.service.NotificationRoutineCommandService;
+import com.vitacheck.service.RoutineQueryService;
 import com.vitacheck.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,17 +20,26 @@ import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
 
-@Tag(name = "notification-routines", description = "복용 루틴 등록 API")
+import java.util.List;
+
+@Tag(name = "notification-routines", description = "복용 루틴 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/notifications")
 public class NotificationRoutineController {
 
     private final NotificationRoutineCommandService notificationRoutineCommandService;
+    private final RoutineQueryService routineQueryService;
     private final UserService userService;
 
     @PostMapping("/routines")
     @Operation(summary = "복용 루틴 등록", description = "현재 로그인한 사용자의 영양제 복용 루틴을 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "복용 루틴 등록 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음")
+    })
     public ResponseEntity<CustomResponse<RoutineRegisterResponseDto>> registerRoutine(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody @Valid RoutineRegisterRequestDto request
@@ -38,5 +51,22 @@ public class NotificationRoutineController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(CustomResponse.created(response));
+    }
+
+    @GetMapping("/routines")
+    @Operation(summary = "복용 루틴 목록 조회", description = "현재 로그인한 사용자의 복용 루틴 전체 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "복용 루틴 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음")
+    })
+    public ResponseEntity<CustomResponse<List<RoutineResponseDto>>> getMyRoutines(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String email = userDetails.getUsername();
+        Long userId = userService.findIdByEmail(email);
+
+        List<RoutineResponseDto> response = routineQueryService.getMyRoutines(userId);
+        return ResponseEntity.ok(CustomResponse.ok(response));
     }
 }

--- a/src/main/java/com/vitacheck/dto/RoutineResponseDto.java
+++ b/src/main/java/com/vitacheck/dto/RoutineResponseDto.java
@@ -1,0 +1,27 @@
+package com.vitacheck.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoutineResponseDto {
+
+    private Long routineId;
+
+    private Long supplementId;
+
+    private String supplementName;
+
+    private String supplementImageUrl;
+
+    private List<String> daysOfWeek; // ex: ["MON", "WED", "FRI"]
+
+    private List<String> times;      // ex: ["08:00", "20:00"]
+}

--- a/src/main/java/com/vitacheck/repository/NotificationRoutineRepository.java
+++ b/src/main/java/com/vitacheck/repository/NotificationRoutineRepository.java
@@ -28,4 +28,6 @@ public interface NotificationRoutineRepository extends JpaRepository<Notificatio
             List<RoutineDayOfWeek> days,
             List<LocalTime> times
     );
+
+    List<NotificationRoutine> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/vitacheck/service/RoutineQueryService.java
+++ b/src/main/java/com/vitacheck/service/RoutineQueryService.java
@@ -1,0 +1,36 @@
+package com.vitacheck.service;
+
+import com.vitacheck.domain.NotificationRoutine;
+import com.vitacheck.dto.RoutineResponseDto;
+import com.vitacheck.repository.NotificationRoutineRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RoutineQueryService {
+
+    private final NotificationRoutineRepository notificationRoutineRepository;
+
+    public List<RoutineResponseDto> getMyRoutines(Long userId) {
+        List<NotificationRoutine> routines = notificationRoutineRepository.findAllByUserId(userId);
+
+        return routines.stream()
+                .map(routine -> RoutineResponseDto.builder()
+                        .routineId(routine.getId())
+                        .supplementId(routine.getSupplement().getId())
+                        .supplementName(routine.getSupplement().getName())
+                        .supplementImageUrl(routine.getSupplement().getImageUrl())
+                        .daysOfWeek(routine.getRoutineDays().stream()
+                                .map(day -> day.getDayOfWeek().name()) // "MON", "WED", ...
+                                .collect(Collectors.toList()))
+                        .times(routine.getRoutineTimes().stream()
+                                .map(time -> time.getTime().toString()) // "08:00"
+                                .collect(Collectors.toList()))
+                        .build())
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
Close #51 

## ## 📝 작업 내용
내 복용 루틴 목록 조회 API (`GET /api/v1/notifications/routines`) 구현

## ## ✅ 변경 사항
`RoutineResponseDto` 생성 (루틴 ID, 영양제 정보, 요일/시간 리스트 포함)
`NotificationRoutineController`에 조회용 API 추가
`RoutineQueryService`에서 stream 기반 DTO 변환
`NotificationRoutineRepository.findAllByUserId(Long userId)` 메서드 추가
Swagger 문서 설명 및 예외 코드 정리


## ## 📷 스크린샷 (선택)
## ## 💬 리뷰어에게