### PR TITLE
feat(#63): FCM setup & 푸쉬 알림 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ out/
 application-local.yml
 
 .DS_Store
+
+firebase-service-account-key.json

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     }
 
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4' // 혹은 최신 안정 버전
+
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 // Q-Type 클래스 생성 위치 지정

--- a/src/main/generated/com/vitacheck/domain/user/QUser.java
+++ b/src/main/generated/com/vitacheck/domain/user/QUser.java
@@ -28,6 +28,8 @@ public class QUser extends EntityPathBase<User> {
 
     public final StringPath email = createString("email");
 
+    public final StringPath fcmToken = createString("fcmToken");
+
     public final StringPath fullName = createString("fullName");
 
     public final EnumPath<Gender> gender = createEnum("gender", Gender.class);

--- a/src/main/java/com/vitacheck/VitacheckBeApplication.java
+++ b/src/main/java/com/vitacheck/VitacheckBeApplication.java
@@ -3,9 +3,11 @@ package com.vitacheck;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing // Auditing 기능 활성화
+@EnableScheduling
 public class VitacheckBeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/vitacheck/config/FirebaseConfig.java
+++ b/src/main/java/com/vitacheck/config/FirebaseConfig.java
@@ -1,0 +1,54 @@
+package com.vitacheck.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+    // 이 Bean이 생성될 때 FirebaseApp 초기화를 먼저 수행합니다.
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        log.info("FirebaseApp 초기화를 시작합니다...");
+
+        ClassPathResource resource = new ClassPathResource("firebase-service-account-key.json");
+        InputStream serviceAccount = resource.getInputStream();
+
+        List<FirebaseApp> firebaseApps = FirebaseApp.getApps();
+        if (firebaseApps != null && !firebaseApps.isEmpty()) {
+            for (FirebaseApp app : firebaseApps) {
+                if (app.getName().equals(FirebaseApp.DEFAULT_APP_NAME)) {
+                    log.info("FirebaseApp이 이미 초기화되었습니다.");
+                    return app;
+                }
+            }
+        }
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        FirebaseApp app = FirebaseApp.initializeApp(options);
+        log.info("FirebaseApp 초기화 성공.");
+        return app;
+    }
+
+    // 위에서 생성된 FirebaseApp Bean을 주입받아 FirebaseMessaging Bean을 생성합니다.
+    // 이렇게 하면 항상 초기화가 완료된 후에 이 메소드가 호출됩니다.
+    @Bean
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+}

--- a/src/main/java/com/vitacheck/config/SecurityConfig.java
+++ b/src/main/java/com/vitacheck/config/SecurityConfig.java
@@ -42,7 +42,9 @@ public class SecurityConfig {
             "/login/**",
             "/oauth2/**",
             // 기타
-            "/error"
+            "/error",
+            "/fcm_test.html",
+            "/firebase-messaging-sw.js"
     };
 
     @Bean

--- a/src/main/java/com/vitacheck/controller/UserController.java
+++ b/src/main/java/com/vitacheck/controller/UserController.java
@@ -4,7 +4,9 @@ import com.vitacheck.dto.UserDto;
 import com.vitacheck.global.apiPayload.CustomResponse;
 import com.vitacheck.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -52,5 +54,24 @@ public class UserController {
         String email = userDetails.getUsername();
         UserDto.InfoResponse updatedInfo = userService.updateMyInfo(email, request);
         return CustomResponse.ok(updatedInfo);
+    }
+
+    @Operation(summary = "FCM 토큰 업데이트", description = "클라이언트(앱/웹)의 푸시 알림을 위한 FCM 디바이스 토큰을 등록 또는 갱신합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "FCM 토큰 업데이트 성공",
+                    content = @Content(examples = @ExampleObject(value = "{\"isSuccess\":true,\"code\":\"COMMON200\",\"message\":\"성공적으로 요청을 수행했습니다.\",\"result\":\"FCM 토큰이 업데이트되었습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(examples = @ExampleObject(value = "{\"isSuccess\":false,\"code\":\"U0001\",\"message\":\"로그인이 필요합니다.\",\"result\":null}"))),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음",
+                    content = @Content(examples = @ExampleObject(value = "{\"isSuccess\":false,\"code\":\"U0002\",\"message\":\"사용자를 찾을 수 없습니다.\",\"result\":null}")))
+    })
+    @PutMapping("/me/fcm-token")
+    public CustomResponse<String> updateFcmToken(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "사용자의 새로운 FCM 디바이스 토큰")
+            @RequestBody UserDto.UpdateFcmTokenRequest request
+    ) {
+        userService.updateFcmToken(userDetails.getUsername(), request.getFcmToken());
+        return CustomResponse.ok("FCM 토큰이 업데이트되었습니다.");
     }
 }

--- a/src/main/java/com/vitacheck/domain/user/User.java
+++ b/src/main/java/com/vitacheck/domain/user/User.java
@@ -54,8 +54,15 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Column(name = "fcm_token", columnDefinition = "TEXT")
+    private String fcmToken;
+
     public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 
     public User updateFromSocial(String nickname) {

--- a/src/main/java/com/vitacheck/dto/UserDto.java
+++ b/src/main/java/com/vitacheck/dto/UserDto.java
@@ -91,4 +91,10 @@ public class UserDto {
         private String fullName;
         private String provider;
     }
+
+    @Getter
+    @NoArgsConstructor
+    public static class UpdateFcmTokenRequest {
+        private String fcmToken;
+    }
 }

--- a/src/main/java/com/vitacheck/repository/NotificationRoutineRepository.java
+++ b/src/main/java/com/vitacheck/repository/NotificationRoutineRepository.java
@@ -30,4 +30,14 @@ public interface NotificationRoutineRepository extends JpaRepository<Notificatio
     );
 
     List<NotificationRoutine> findAllByUserId(Long userId);
+
+    @Query("""
+        SELECT r FROM NotificationRoutine r
+        JOIN FETCH r.user
+        JOIN FETCH r.supplement
+        WHERE r.isEnabled = true
+          AND r.id IN (SELECT rd.notificationRoutine.id FROM RoutineDay rd WHERE rd.dayOfWeek = :dayOfWeek)
+          AND r.id IN (SELECT rt.notificationRoutine.id FROM RoutineTime rt WHERE rt.time = :time)
+    """)
+    List<NotificationRoutine> findRoutinesToSend(RoutineDayOfWeek dayOfWeek, LocalTime time);
 }

--- a/src/main/java/com/vitacheck/service/FcmService.java
+++ b/src/main/java/com/vitacheck/service/FcmService.java
@@ -1,0 +1,41 @@
+package com.vitacheck.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmService {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    public void sendNotification(String token, String title, String body) {
+        if (token == null || token.isEmpty()) {
+            log.warn("FCM 토큰이 비어있어 알림을 보낼 수 없습니다.");
+            return;
+        }
+
+        Notification notification = Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .build();
+
+        Message message = Message.builder()
+                .setToken(token)
+                .setNotification(notification)
+                .build();
+
+        try {
+            firebaseMessaging.send(message);
+            log.info("FCM 알림 발송 성공: To = {}, Title = {}", token, title);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 알림 발송 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/vitacheck/service/NotificationScheduler.java
+++ b/src/main/java/com/vitacheck/service/NotificationScheduler.java
@@ -1,0 +1,69 @@
+package com.vitacheck.service;
+
+import com.vitacheck.domain.NotificationRoutine;
+import com.vitacheck.domain.RoutineDayOfWeek;
+import com.vitacheck.repository.NotificationRoutineRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final NotificationRoutineRepository notificationRoutineRepository;
+    private final FcmService fcmService;
+
+    @Scheduled(cron = "0 * * * * *") // 매분 0초에 실행
+    public void sendRoutineNotifications() {
+        LocalDateTime now = LocalDateTime.now();
+        DayOfWeek currentDay = now.getDayOfWeek();
+        LocalTime currentTime = now.toLocalTime().withSecond(0).withNano(0);
+
+        // 👇👇👇 여기가 수정된 요일 변환 로직입니다! 👇👇👇
+        RoutineDayOfWeek routineDay = convertToRoutineDayOfWeek(currentDay);
+        if (routineDay == null) {
+            log.warn("오늘은 알림을 보내는 요일이 아닙니다: {}", currentDay);
+            return;
+        }
+
+        log.info("{} {}시 {}분에 발송될 알림을 찾습니다.", routineDay, currentTime.getHour(), currentTime.getMinute());
+
+        List<NotificationRoutine> routines = notificationRoutineRepository.findRoutinesToSend(
+                routineDay,
+                currentTime
+        );
+
+        if (routines.isEmpty()) {
+            log.info("발송할 알림이 없습니다.");
+            return;
+        }
+
+        for (NotificationRoutine routine : routines) {
+            String fcmToken = routine.getUser().getFcmToken();
+            String title = "💊 영양제 복용 시간입니다!";
+            String body = String.format("'%s'를 복용할 시간이에요.", routine.getSupplement().getName());
+            fcmService.sendNotification(fcmToken, title, body);
+        }
+    }
+
+    // 👇👇👇 요일 변환을 위한 헬퍼 메소드 추가 👇👇👇
+    private RoutineDayOfWeek convertToRoutineDayOfWeek(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> RoutineDayOfWeek.MON;
+            case TUESDAY -> RoutineDayOfWeek.TUE;
+            case WEDNESDAY -> RoutineDayOfWeek.WED;
+            case THURSDAY -> RoutineDayOfWeek.THU;
+            case FRIDAY -> RoutineDayOfWeek.FRI;
+            case SATURDAY -> RoutineDayOfWeek.SAT;
+            case SUNDAY -> RoutineDayOfWeek.SUN;
+        };
+    }
+}

--- a/src/main/java/com/vitacheck/service/UserService.java
+++ b/src/main/java/com/vitacheck/service/UserService.java
@@ -109,4 +109,10 @@ public class UserService {
         return user.getId();
     }
 
+    @Transactional
+    public void updateFcmToken(String email, String fcmToken) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        user.updateFcmToken(fcmToken);
+    }
 }

--- a/src/main/resources/static/fcm_test.html
+++ b/src/main/resources/static/fcm_test.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>FCM Token Retriever</title>
+    <meta charset="UTF-8"> </head>
+<body>
+<h1>FCM Token Test</h1>
+<p>알림 권한을 허용하면 아래에 토큰이 나타납니다.</p>
+<textarea id="token" rows="10" cols="100" readonly></textarea>
+
+<script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
+<script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-messaging.js"></script>
+
+<script>
+    // 1. Your web app's Firebase configuration
+    const firebaseConfig = {
+        apiKey: "AIzaSyDhCaf3Ockukla3eR3lx4B3m9TsDhvscMY",
+        authDomain: "vitacheck-1ee1d.firebaseapp.com",
+        projectId: "vitacheck-1ee1d",
+        storageBucket: "vitacheck-1ee1d.appspot.com",
+        messagingSenderId: "802557675495",
+        appId: "1:802557675495:web:7c6c855f4ca135ca049f42",
+    };
+
+    // 2. Firebase 앱 초기화 (v8 방식)
+    firebase.initializeApp(firebaseConfig);
+    const messaging = firebase.messaging();
+
+    // 3. 알림 권한 요청 및 토큰 가져오기
+    function requestPermission() {
+        console.log("Requesting permission...");
+        Notification.requestPermission().then((permission) => {
+            if (permission === "granted") {
+                console.log("Notification permission granted.");
+
+                messaging.getToken({
+                    vapidKey: "BK0KbSph5fprJ_iCVjANgSOi6CevMdhXLfaEbUhZ8CkeQimGFP3GafoZX4yAcTvtW5vRWZHL4Qwe63HXZ2uEBLQ",
+                })
+                    .then((currentToken) => {
+                        if (currentToken) {
+                            console.log("Token:", currentToken);
+                            document.getElementById("token").value = currentToken;
+                        } else {
+                            console.log("No registration token available. Request permission to generate one.");
+                        }
+                    })
+                    .catch((err) => {
+                        console.log("An error occurred while retrieving token. ", err);
+                    });
+            } else {
+                console.log("Unable to get permission to notify.");
+            }
+        });
+    }
+
+    requestPermission();
+</script>
+</body>
+</html>

--- a/src/main/resources/static/firebase-messaging-sw.js
+++ b/src/main/resources/static/firebase-messaging-sw.js
@@ -1,0 +1,35 @@
+// Firebase v8 SDK 스크립트를 가져옵니다.
+importScripts('https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js');
+importScripts('https://www.gstatic.com/firebasejs/8.10.1/firebase-messaging.js');
+
+// 1. 여기에 fcm_test.html에 사용했던 firebaseConfig 코드를 그대로 붙여넣으세요.
+const firebaseConfig = {
+    apiKey: "AIzaSyDhCaf3Ockukla3eR3lx4B3m9TsDhvscMY",
+    authDomain: "vitacheck-1ee1d.firebaseapp.com",
+    projectId: "vitacheck-1ee1d",
+    storageBucket: "vitacheck-1ee1d.appspot.com",
+    messagingSenderId: "802557675495",
+    appId: "1:802557675495:web:7c6c855f4ca135ca049f42",
+};
+
+// 2. Firebase 앱 초기화
+firebase.initializeApp(firebaseConfig);
+
+const messaging = firebase.messaging();
+
+// 3. (선택) 백그라운드에서 메시지를 받았을 때 처리하는 로직
+//    (지금은 비워두어도 토큰 발급에는 문제 없습니다.)
+messaging.onBackgroundMessage((payload) => {
+    console.log(
+        '[firebase-messaging-sw.js] Received background message ',
+        payload
+    );
+    // Customize notification here
+    const notificationTitle = 'Background Message Title';
+    const notificationOptions = {
+        body: 'Background Message body.',
+        icon: '/firebase-logo.png'
+    };
+
+    self.registration.showNotification(notificationTitle, notificationOptions);
+});

--- a/src/test/java/Service.java
+++ b/src/test/java/Service.java
@@ -1,0 +1,2 @@
+public class Service {
+}

--- a/src/test/java/com/vitacheck/service/NotificationSchedulerTest.java
+++ b/src/test/java/com/vitacheck/service/NotificationSchedulerTest.java
@@ -1,0 +1,81 @@
+package com.vitacheck.service;
+
+import com.vitacheck.domain.NotificationRoutine;
+import com.vitacheck.domain.RoutineDayOfWeek;
+import com.vitacheck.domain.Supplement;
+import com.vitacheck.domain.user.User;
+import com.vitacheck.repository.NotificationRoutineRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationSchedulerTest {
+
+    @Mock
+    private NotificationRoutineRepository notificationRoutineRepository;
+
+    @Mock
+    private FcmService fcmService;
+
+    @InjectMocks
+    private NotificationScheduler notificationScheduler;
+
+    private User testUser;
+    private Supplement testSupplement;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트에 사용할 가짜 유저와 영양제 객체 생성
+        testUser = User.builder()
+                .id(1L)
+                .fcmToken("test_fcm_token_12345") // FCM 토큰 설정
+                .build();
+
+        testSupplement = Supplement.builder()
+                .id(10L)
+                .name("비타민C 1000")
+                .build();
+    }
+
+    @Test
+    @DisplayName("스케줄러가 현재 시간에 맞는 루틴을 찾아 알림을 성공적으로 발송한다")
+    void sendRoutineNotifications_Success() {
+        // given: 준비
+        // 1. 테스트용 가짜 루틴 객체 생성
+        NotificationRoutine routine = NotificationRoutine.builder()
+                .user(testUser)
+                .supplement(testSupplement)
+                .build();
+
+        // 2. Repository가 특정 요일과 시간을 받으면 위에서 만든 가짜 루틴을 반환하도록 설정
+        when(notificationRoutineRepository.findRoutinesToSend(
+                any(RoutineDayOfWeek.class), // 어떤 요일이든
+                any(LocalTime.class)      // 어떤 시간이든
+        )).thenReturn(List.of(routine));
+
+        // when: 실행
+        // 스케줄러의 public 메소드를 직접 호출
+        notificationScheduler.sendRoutineNotifications();
+
+        // then: 검증
+        // FcmService의 sendNotification 메소드가 정확히 1번 호출되었는지 확인
+        // 그리고 어떤 파라미터로 호출되었는지 검증
+        verify(fcmService, times(1)).sendNotification(
+                eq("test_fcm_token_12345"),                  // FCM 토큰이 올바른가?
+                eq("💊 영양제 복용 시간입니다!"),                // 제목이 올바른가?
+                eq("'비타민C 1000'를 복용할 시간이에요.")       // 본문이 올바른가?
+        );
+    }
+}


### PR DESCRIPTION
Close #63

## ## 📝 작업 내용
사용자가 설정한 복용 루틴에 맞춰 푸시 알림을 받을 수 있도록 FCM(Firebase Cloud Messaging) 기반의 알림 기능을 구현합니다.

주요 기능은 클라이언트의 FCM 토큰을 저장하고, 스케줄러를 통해 지정된 시간에 알림을 발송하는 것입니다.

## ## ✅ 변경 사항
- **Firebase 연동**
  - `build.gradle`: `firebase-admin` 의존성을 추가했습니다.
  - `FirebaseConfig.java`: 서버 시작 시 Firebase 앱을 초기화하고 `FirebaseMessaging` Bean을 등록하는 설정 클래스를 추가했습니다.
  - `firebase-service-account-key.json`: Firebase 서비스 계정 키를 `resources` 폴더에 추가하고, `.gitignore`에 등록하여 외부에 노출되지 않도록 처리했습니다.

- **FCM 토큰 관리**
  - `User.java`: FCM 디바이스 토큰을 저장하기 위한 `fcmToken` 필드와 업데이트 메서드를 추가했습니다.
  - `UserController.java`, `UserService.java`, `UserDto.java`: 클라이언트로부터 FCM 토큰을 받아와 DB에 저장/수정하는 API(`PUT /api/v1/users/me/fcm-token`)와 관련 로직을 구현했습니다.

- **알림 발송 로직**
  - `FcmService.java`: `FirebaseMessaging`을 사용하여 실제 알림 메시지를 전송하는 서비스를 구현했습니다.

- **자동 스케줄링**
  - `VitacheckBeApplication.java`: `@EnableScheduling` 어노테이션을 추가하여 스케줄링 기능을 활성화했습니다.
  - `NotificationScheduler.java`: 매분마다 실행되어 현재 시간에 맞는 알림 대상을 DB에서 조회하고, `FcmService`를 호출하여 알림을 발송하는 스케줄러를 구현했습니다.
  - `NotificationRoutineRepository.java`: 스케줄러가 사용할, 현재 시간에 맞는 복용 루틴을 조회하는 쿼리 메소드를 추가했습니다.


## ## 💬 리뷰어에게
FCM 푸시 알림 기능의 백엔드 로직을 모두 구현했습니다.

리뷰하실 때 `NotificationScheduler`의 시간대별 조회 로직과 `FcmService`의 메시지 전송 부분을 중점적으로 봐주시면 감사하겠습니다.

이제 클라이언트(웹/앱)에서 FCM SDK를 통해 발급받은 토큰을 `/api/v1/users/me/fcm-token` API로 보내주는 연동 작업이 필요합니다.