### PR TITLE
feat(#71): 알림설정 엔티티 구현 및 로직 변경

### DIFF
--- a/src/main/generated/com/vitacheck/domain/QBrand.java
+++ b/src/main/generated/com/vitacheck/domain/QBrand.java
@@ -20,7 +20,7 @@ public class QBrand extends EntityPathBase<Brand> {
 
     public static final QBrand brand = new QBrand("brand");
 
-    public final QBaseTimeEntity _super = new QBaseTimeEntity(this);
+    public final com.vitacheck.domain.common.QBaseTimeEntity _super = new com.vitacheck.domain.common.QBaseTimeEntity(this);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;

--- a/src/main/generated/com/vitacheck/domain/QLike.java
+++ b/src/main/generated/com/vitacheck/domain/QLike.java
@@ -22,7 +22,7 @@ public class QLike extends EntityPathBase<Like> {
 
     public static final QLike like = new QLike("like1");
 
-    public final QBaseTimeEntity _super = new QBaseTimeEntity(this);
+    public final com.vitacheck.domain.common.QBaseTimeEntity _super = new com.vitacheck.domain.common.QBaseTimeEntity(this);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;

--- a/src/main/generated/com/vitacheck/domain/QRoutineDay.java
+++ b/src/main/generated/com/vitacheck/domain/QRoutineDay.java
@@ -26,7 +26,7 @@ public class QRoutineDay extends EntityPathBase<RoutineDay> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    public final QNotificationRoutine notificationRoutine;
+    public final com.vitacheck.domain.notification.QNotificationRoutine notificationRoutine;
 
     public QRoutineDay(String variable) {
         this(RoutineDay.class, forVariable(variable), INITS);
@@ -46,7 +46,7 @@ public class QRoutineDay extends EntityPathBase<RoutineDay> {
 
     public QRoutineDay(Class<? extends RoutineDay> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.notificationRoutine = inits.isInitialized("notificationRoutine") ? new QNotificationRoutine(forProperty("notificationRoutine"), inits.get("notificationRoutine")) : null;
+        this.notificationRoutine = inits.isInitialized("notificationRoutine") ? new com.vitacheck.domain.notification.QNotificationRoutine(forProperty("notificationRoutine"), inits.get("notificationRoutine")) : null;
     }
 
 }

--- a/src/main/generated/com/vitacheck/domain/QRoutineTime.java
+++ b/src/main/generated/com/vitacheck/domain/QRoutineTime.java
@@ -24,7 +24,7 @@ public class QRoutineTime extends EntityPathBase<RoutineTime> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    public final QNotificationRoutine notificationRoutine;
+    public final com.vitacheck.domain.notification.QNotificationRoutine notificationRoutine;
 
     public final TimePath<java.time.LocalTime> time = createTime("time", java.time.LocalTime.class);
 
@@ -46,7 +46,7 @@ public class QRoutineTime extends EntityPathBase<RoutineTime> {
 
     public QRoutineTime(Class<? extends RoutineTime> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.notificationRoutine = inits.isInitialized("notificationRoutine") ? new QNotificationRoutine(forProperty("notificationRoutine"), inits.get("notificationRoutine")) : null;
+        this.notificationRoutine = inits.isInitialized("notificationRoutine") ? new com.vitacheck.domain.notification.QNotificationRoutine(forProperty("notificationRoutine"), inits.get("notificationRoutine")) : null;
     }
 
 }

--- a/src/main/generated/com/vitacheck/domain/QSupplement.java
+++ b/src/main/generated/com/vitacheck/domain/QSupplement.java
@@ -22,7 +22,7 @@ public class QSupplement extends EntityPathBase<Supplement> {
 
     public static final QSupplement supplement = new QSupplement("supplement");
 
-    public final QBaseTimeEntity _super = new QBaseTimeEntity(this);
+    public final com.vitacheck.domain.common.QBaseTimeEntity _super = new com.vitacheck.domain.common.QBaseTimeEntity(this);
 
     public final QBrand brand;
 
@@ -44,7 +44,7 @@ public class QSupplement extends EntityPathBase<Supplement> {
 
     public final NumberPath<Integer> price = createNumber("price", Integer.class);
 
-    public final ListPath<SupplementIngredient, QSupplementIngredient> supplementIngredients = this.<SupplementIngredient, QSupplementIngredient>createList("supplementIngredients", SupplementIngredient.class, QSupplementIngredient.class, PathInits.DIRECT2);
+    public final ListPath<com.vitacheck.domain.mapping.SupplementIngredient, com.vitacheck.domain.mapping.QSupplementIngredient> supplementIngredients = this.<com.vitacheck.domain.mapping.SupplementIngredient, com.vitacheck.domain.mapping.QSupplementIngredient>createList("supplementIngredients", com.vitacheck.domain.mapping.SupplementIngredient.class, com.vitacheck.domain.mapping.QSupplementIngredient.class, PathInits.DIRECT2);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;

--- a/src/main/generated/com/vitacheck/domain/combination/QCombination.java
+++ b/src/main/generated/com/vitacheck/domain/combination/QCombination.java
@@ -1,4 +1,4 @@
-package com.vitacheck.domain.Combination;
+package com.vitacheck.domain.combination;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -15,7 +15,7 @@ import com.querydsl.core.types.Path;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QCombination extends EntityPathBase<Combination> {
 
-    private static final long serialVersionUID = 360809113L;
+    private static final long serialVersionUID = 1538566841L;
 
     public static final QCombination combination = new QCombination("combination");
 

--- a/src/main/generated/com/vitacheck/domain/common/QBaseTimeEntity.java
+++ b/src/main/generated/com/vitacheck/domain/common/QBaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.vitacheck.domain;
+package com.vitacheck.domain.common;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -15,7 +15,7 @@ import com.querydsl.core.types.Path;
 @Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
 public class QBaseTimeEntity extends EntityPathBase<BaseTimeEntity> {
 
-    private static final long serialVersionUID = -705295336L;
+    private static final long serialVersionUID = 332290093L;
 
     public static final QBaseTimeEntity baseTimeEntity = new QBaseTimeEntity("baseTimeEntity");
 

--- a/src/main/generated/com/vitacheck/domain/mapping/QSupplementIngredient.java
+++ b/src/main/generated/com/vitacheck/domain/mapping/QSupplementIngredient.java
@@ -1,4 +1,4 @@
-package com.vitacheck.domain;
+package com.vitacheck.domain.mapping;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -16,7 +16,7 @@ import com.querydsl.core.types.dsl.PathInits;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QSupplementIngredient extends EntityPathBase<SupplementIngredient> {
 
-    private static final long serialVersionUID = -1344775295L;
+    private static final long serialVersionUID = 344434081L;
 
     private static final PathInits INITS = PathInits.DIRECT2;
 
@@ -26,9 +26,9 @@ public class QSupplementIngredient extends EntityPathBase<SupplementIngredient> 
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    public final QIngredient ingredient;
+    public final com.vitacheck.domain.QIngredient ingredient;
 
-    public final QSupplement supplement;
+    public final com.vitacheck.domain.QSupplement supplement;
 
     public final StringPath unit = createString("unit");
 
@@ -50,8 +50,8 @@ public class QSupplementIngredient extends EntityPathBase<SupplementIngredient> 
 
     public QSupplementIngredient(Class<? extends SupplementIngredient> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.ingredient = inits.isInitialized("ingredient") ? new QIngredient(forProperty("ingredient")) : null;
-        this.supplement = inits.isInitialized("supplement") ? new QSupplement(forProperty("supplement"), inits.get("supplement")) : null;
+        this.ingredient = inits.isInitialized("ingredient") ? new com.vitacheck.domain.QIngredient(forProperty("ingredient")) : null;
+        this.supplement = inits.isInitialized("supplement") ? new com.vitacheck.domain.QSupplement(forProperty("supplement"), inits.get("supplement")) : null;
     }
 
 }

--- a/src/main/generated/com/vitacheck/domain/notification/QNotificationRoutine.java
+++ b/src/main/generated/com/vitacheck/domain/notification/QNotificationRoutine.java
@@ -1,4 +1,4 @@
-package com.vitacheck.domain;
+package com.vitacheck.domain.notification;
 
 import static com.querydsl.core.types.PathMetadataFactory.*;
 
@@ -16,13 +16,13 @@ import com.querydsl.core.types.dsl.PathInits;
 @Generated("com.querydsl.codegen.DefaultEntitySerializer")
 public class QNotificationRoutine extends EntityPathBase<NotificationRoutine> {
 
-    private static final long serialVersionUID = -722027934L;
+    private static final long serialVersionUID = -2035847891L;
 
     private static final PathInits INITS = PathInits.DIRECT2;
 
     public static final QNotificationRoutine notificationRoutine = new QNotificationRoutine("notificationRoutine");
 
-    public final QBaseTimeEntity _super = new QBaseTimeEntity(this);
+    public final com.vitacheck.domain.common.QBaseTimeEntity _super = new com.vitacheck.domain.common.QBaseTimeEntity(this);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
@@ -31,11 +31,11 @@ public class QNotificationRoutine extends EntityPathBase<NotificationRoutine> {
 
     public final BooleanPath isEnabled = createBoolean("isEnabled");
 
-    public final ListPath<RoutineDay, QRoutineDay> routineDays = this.<RoutineDay, QRoutineDay>createList("routineDays", RoutineDay.class, QRoutineDay.class, PathInits.DIRECT2);
+    public final ListPath<com.vitacheck.domain.RoutineDay, com.vitacheck.domain.QRoutineDay> routineDays = this.<com.vitacheck.domain.RoutineDay, com.vitacheck.domain.QRoutineDay>createList("routineDays", com.vitacheck.domain.RoutineDay.class, com.vitacheck.domain.QRoutineDay.class, PathInits.DIRECT2);
 
-    public final ListPath<RoutineTime, QRoutineTime> routineTimes = this.<RoutineTime, QRoutineTime>createList("routineTimes", RoutineTime.class, QRoutineTime.class, PathInits.DIRECT2);
+    public final ListPath<com.vitacheck.domain.RoutineTime, com.vitacheck.domain.QRoutineTime> routineTimes = this.<com.vitacheck.domain.RoutineTime, com.vitacheck.domain.QRoutineTime>createList("routineTimes", com.vitacheck.domain.RoutineTime.class, com.vitacheck.domain.QRoutineTime.class, PathInits.DIRECT2);
 
-    public final QSupplement supplement;
+    public final com.vitacheck.domain.QSupplement supplement;
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
@@ -60,7 +60,7 @@ public class QNotificationRoutine extends EntityPathBase<NotificationRoutine> {
 
     public QNotificationRoutine(Class<? extends NotificationRoutine> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
-        this.supplement = inits.isInitialized("supplement") ? new QSupplement(forProperty("supplement"), inits.get("supplement")) : null;
+        this.supplement = inits.isInitialized("supplement") ? new com.vitacheck.domain.QSupplement(forProperty("supplement"), inits.get("supplement")) : null;
         this.user = inits.isInitialized("user") ? new com.vitacheck.domain.user.QUser(forProperty("user")) : null;
     }
 

--- a/src/main/generated/com/vitacheck/domain/notification/QNotificationSettings.java
+++ b/src/main/generated/com/vitacheck/domain/notification/QNotificationSettings.java
@@ -1,0 +1,57 @@
+package com.vitacheck.domain.notification;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNotificationSettings is a Querydsl query type for NotificationSettings
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNotificationSettings extends EntityPathBase<NotificationSettings> {
+
+    private static final long serialVersionUID = -1552663334L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNotificationSettings notificationSettings = new QNotificationSettings("notificationSettings");
+
+    public final EnumPath<NotificationChannel> channel = createEnum("channel", NotificationChannel.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isEnabled = createBoolean("isEnabled");
+
+    public final EnumPath<NotificationType> type = createEnum("type", NotificationType.class);
+
+    public final com.vitacheck.domain.user.QUser user;
+
+    public QNotificationSettings(String variable) {
+        this(NotificationSettings.class, forVariable(variable), INITS);
+    }
+
+    public QNotificationSettings(Path<? extends NotificationSettings> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNotificationSettings(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNotificationSettings(PathMetadata metadata, PathInits inits) {
+        this(NotificationSettings.class, metadata, inits);
+    }
+
+    public QNotificationSettings(Class<? extends NotificationSettings> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new com.vitacheck.domain.user.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/vitacheck/domain/user/QUser.java
+++ b/src/main/generated/com/vitacheck/domain/user/QUser.java
@@ -19,7 +19,7 @@ public class QUser extends EntityPathBase<User> {
 
     public static final QUser user = new QUser("user");
 
-    public final com.vitacheck.domain.QBaseTimeEntity _super = new com.vitacheck.domain.QBaseTimeEntity(this);
+    public final com.vitacheck.domain.common.QBaseTimeEntity _super = new com.vitacheck.domain.common.QBaseTimeEntity(this);
 
     public final DatePath<java.time.LocalDate> birthDate = createDate("birthDate", java.time.LocalDate.class);
 

--- a/src/main/java/com/vitacheck/controller/NotificationSettingsController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationSettingsController.java
@@ -1,0 +1,45 @@
+package com.vitacheck.controller;
+
+import com.vitacheck.dto.NotificationSettingsDto;
+import com.vitacheck.global.apiPayload.CustomResponse;
+import com.vitacheck.service.NotificationSettingsService;
+import com.vitacheck.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "notification-settings", description = "사용자 알림 설정 API")
+@RestController
+@RequestMapping("/api/v1/notification-settings")
+@RequiredArgsConstructor
+public class NotificationSettingsController {
+
+    private final NotificationSettingsService notificationSettingsService;
+    private final UserService userService;
+
+    @GetMapping("/me")
+    @Operation(summary = "내 알림 설정 조회", description = "현재 로그인한 사용자의 모든 알림 수신 동의 여부를 조회합니다.")
+    public CustomResponse<List<NotificationSettingsDto>> getMyNotificationSettings(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long userId = userService.findIdByEmail(userDetails.getUsername());
+        List<NotificationSettingsDto> response = notificationSettingsService.getNotificationSettings(userId);
+        return CustomResponse.ok(response);
+    }
+
+    @PutMapping("/me")
+    @Operation(summary = "내 알림 설정 변경", description = "특정 알림(종류/채널)의 수신 동의 여부를 변경(토글)합니다.")
+    public CustomResponse<String> updateMyNotificationSetting(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody NotificationSettingsDto.UpdateRequest request
+    ) {
+        Long userId = userService.findIdByEmail(userDetails.getUsername());
+        notificationSettingsService.updateNotificationSetting(userId, request);
+        return CustomResponse.ok("알림 설정이 변경되었습니다.");
+    }
+}

--- a/src/main/java/com/vitacheck/domain/Brand.java
+++ b/src/main/java/com/vitacheck/domain/Brand.java
@@ -1,5 +1,6 @@
 package com.vitacheck.domain;
 
+import com.vitacheck.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/vitacheck/domain/Like.java
+++ b/src/main/java/com/vitacheck/domain/Like.java
@@ -1,5 +1,6 @@
 package com.vitacheck.domain;
 
+import com.vitacheck.domain.common.BaseTimeEntity;
 import com.vitacheck.domain.user.User;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/vitacheck/domain/RoutineDay.java
+++ b/src/main/java/com/vitacheck/domain/RoutineDay.java
@@ -1,5 +1,6 @@
 package com.vitacheck.domain;
 
+import com.vitacheck.domain.notification.NotificationRoutine;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/vitacheck/domain/RoutineTime.java
+++ b/src/main/java/com/vitacheck/domain/RoutineTime.java
@@ -1,5 +1,6 @@
 package com.vitacheck.domain;
 
+import com.vitacheck.domain.notification.NotificationRoutine;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/vitacheck/domain/Supplement.java
+++ b/src/main/java/com/vitacheck/domain/Supplement.java
@@ -1,5 +1,7 @@
 package com.vitacheck.domain;
 
+import com.vitacheck.domain.common.BaseTimeEntity;
+import com.vitacheck.domain.mapping.SupplementIngredient;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/vitacheck/domain/combination/Combination.java
+++ b/src/main/java/com/vitacheck/domain/combination/Combination.java
@@ -1,4 +1,4 @@
-package com.vitacheck.domain.Combination;
+package com.vitacheck.domain.combination;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/vitacheck/domain/combination/RecommandType.java
+++ b/src/main/java/com/vitacheck/domain/combination/RecommandType.java
@@ -1,4 +1,4 @@
-package com.vitacheck.domain.Combination;
+package com.vitacheck.domain.combination;
 
 public enum RecommandType {
     GOOD, CAUTION

--- a/src/main/java/com/vitacheck/domain/common/BaseTimeEntity.java
+++ b/src/main/java/com/vitacheck/domain/common/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.vitacheck.domain;
+package com.vitacheck.domain.common;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/src/main/java/com/vitacheck/domain/mapping/SupplementIngredient.java
+++ b/src/main/java/com/vitacheck/domain/mapping/SupplementIngredient.java
@@ -1,5 +1,7 @@
-package com.vitacheck.domain;
+package com.vitacheck.domain.mapping;
 
+import com.vitacheck.domain.Ingredient;
+import com.vitacheck.domain.Supplement;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/vitacheck/domain/notification/NotificationChannel.java
+++ b/src/main/java/com/vitacheck/domain/notification/NotificationChannel.java
@@ -1,0 +1,7 @@
+package com.vitacheck.domain.notification;
+
+public enum NotificationChannel {
+    EMAIL,
+    SMS,
+    PUSH
+}

--- a/src/main/java/com/vitacheck/domain/notification/NotificationRoutine.java
+++ b/src/main/java/com/vitacheck/domain/notification/NotificationRoutine.java
@@ -1,5 +1,9 @@
-package com.vitacheck.domain;
+package com.vitacheck.domain.notification;
 
+import com.vitacheck.domain.common.BaseTimeEntity;
+import com.vitacheck.domain.RoutineDay;
+import com.vitacheck.domain.RoutineTime;
+import com.vitacheck.domain.Supplement;
 import com.vitacheck.domain.user.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/vitacheck/domain/notification/NotificationSettings.java
+++ b/src/main/java/com/vitacheck/domain/notification/NotificationSettings.java
@@ -1,0 +1,37 @@
+package com.vitacheck.domain.notification;
+
+import com.vitacheck.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "notification_settings")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class NotificationSettings {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type; // 알림 종류 (EVENT, INTAKE)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationChannel channel; // 알림 채널 (EMAIL, SMS, PUSH)
+
+    @Column(nullable = false)
+    private boolean isEnabled; // 수신 동의 여부 (true/false)
+
+    public void setIsEnabled(boolean isEnabled) {
+        this.isEnabled = isEnabled;
+    }
+}

--- a/src/main/java/com/vitacheck/domain/notification/NotificationType.java
+++ b/src/main/java/com/vitacheck/domain/notification/NotificationType.java
@@ -1,0 +1,6 @@
+package com.vitacheck.domain.notification;
+
+public enum NotificationType {
+    EVENT, // 이벤트 및 혜택
+    INTAKE // 섭취 알림
+}

--- a/src/main/java/com/vitacheck/domain/user/User.java
+++ b/src/main/java/com/vitacheck/domain/user/User.java
@@ -1,6 +1,6 @@
 package com.vitacheck.domain.user;
 
-import com.vitacheck.domain.BaseTimeEntity;
+import com.vitacheck.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/vitacheck/dto/CombinationDTO.java
+++ b/src/main/java/com/vitacheck/dto/CombinationDTO.java
@@ -1,7 +1,7 @@
 package com.vitacheck.dto;
 
-import com.vitacheck.domain.Combination.Combination;
-import com.vitacheck.domain.Combination.RecommandType;
+import com.vitacheck.domain.combination.Combination;
+import com.vitacheck.domain.combination.RecommandType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/vitacheck/dto/NotificationSettingsDto.java
+++ b/src/main/java/com/vitacheck/dto/NotificationSettingsDto.java
@@ -1,0 +1,32 @@
+package com.vitacheck.dto;
+
+import com.vitacheck.domain.notification.NotificationChannel;
+import com.vitacheck.domain.notification.NotificationSettings;
+import com.vitacheck.domain.notification.NotificationType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+public class NotificationSettingsDto {
+    private NotificationType type;
+    private NotificationChannel channel;
+    private boolean isEnabled;
+
+    public static NotificationSettingsDto from(NotificationSettings settings) {
+        return NotificationSettingsDto.builder()
+                .type(settings.getType())
+                .channel(settings.getChannel())
+                .isEnabled(settings.isEnabled())
+                .build();
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class UpdateRequest {
+        private NotificationType type;
+        private NotificationChannel channel;
+        private boolean isEnabled;
+    }
+}

--- a/src/main/java/com/vitacheck/dto/SupplementDto.java
+++ b/src/main/java/com/vitacheck/dto/SupplementDto.java
@@ -1,9 +1,7 @@
 package com.vitacheck.dto;
 
-import com.vitacheck.domain.Brand;
-import com.vitacheck.domain.Ingredient;
 import com.vitacheck.domain.Supplement;
-import com.vitacheck.domain.SupplementIngredient;
+import com.vitacheck.domain.mapping.SupplementIngredient;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/vitacheck/repository/CombinationRepository.java
+++ b/src/main/java/com/vitacheck/repository/CombinationRepository.java
@@ -1,6 +1,6 @@
 package com.vitacheck.repository;
 
-import com.vitacheck.domain.Combination.Combination;
+import com.vitacheck.domain.combination.Combination;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CombinationRepository extends JpaRepository<Combination, Long> {

--- a/src/main/java/com/vitacheck/repository/NotificationRoutineRepository.java
+++ b/src/main/java/com/vitacheck/repository/NotificationRoutineRepository.java
@@ -1,6 +1,6 @@
 package com.vitacheck.repository;
 
-import com.vitacheck.domain.NotificationRoutine;
+import com.vitacheck.domain.notification.NotificationRoutine;
 import com.vitacheck.domain.RoutineDayOfWeek;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/vitacheck/repository/NotificationSettingsRepository.java
+++ b/src/main/java/com/vitacheck/repository/NotificationSettingsRepository.java
@@ -1,0 +1,17 @@
+package com.vitacheck.repository;
+
+import com.vitacheck.domain.notification.NotificationChannel;
+import com.vitacheck.domain.notification.NotificationSettings;
+import com.vitacheck.domain.notification.NotificationType;
+import com.vitacheck.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface NotificationSettingsRepository extends JpaRepository<NotificationSettings, Long> {
+    List<NotificationSettings> findByUser(User user);
+    Optional<NotificationSettings> findByUserAndTypeAndChannel(User user, NotificationType type, NotificationChannel channel);
+}

--- a/src/main/java/com/vitacheck/repository/SupplementRepositoryImpl.java
+++ b/src/main/java/com/vitacheck/repository/SupplementRepositoryImpl.java
@@ -10,7 +10,7 @@ import org.springframework.util.StringUtils;
 import java.util.List;
 
 import static com.vitacheck.domain.QSupplement.supplement;
-import static com.vitacheck.domain.QSupplementIngredient.supplementIngredient;
+import static com.vitacheck.domain.mapping.QSupplementIngredient.supplementIngredient;
 import static com.vitacheck.domain.QBrand.brand;
 
 @Repository

--- a/src/main/java/com/vitacheck/service/CombinationService.java
+++ b/src/main/java/com/vitacheck/service/CombinationService.java
@@ -1,7 +1,7 @@
 package com.vitacheck.service;
 
-import com.vitacheck.domain.Combination.Combination;
-import com.vitacheck.domain.Combination.RecommandType;
+import com.vitacheck.domain.combination.Combination;
+import com.vitacheck.domain.combination.RecommandType;
 import com.vitacheck.dto.CombinationDTO;
 import com.vitacheck.repository.CombinationRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/vitacheck/service/NotificationRoutineCommandService.java
+++ b/src/main/java/com/vitacheck/service/NotificationRoutineCommandService.java
@@ -1,7 +1,7 @@
 package com.vitacheck.service;
 
-import com.amazonaws.services.kms.model.NotFoundException;
 import com.vitacheck.domain.*;
+import com.vitacheck.domain.notification.NotificationRoutine;
 import com.vitacheck.domain.user.User;
 import com.vitacheck.dto.RoutineRegisterRequestDto;
 import com.vitacheck.dto.RoutineRegisterResponseDto;

--- a/src/main/java/com/vitacheck/service/NotificationSettingsService.java
+++ b/src/main/java/com/vitacheck/service/NotificationSettingsService.java
@@ -1,0 +1,73 @@
+package com.vitacheck.service;
+
+import com.vitacheck.domain.notification.NotificationChannel;
+import com.vitacheck.domain.notification.NotificationSettings;
+import com.vitacheck.domain.notification.NotificationType;
+import com.vitacheck.domain.user.User;
+import com.vitacheck.dto.NotificationSettingsDto;
+import com.vitacheck.global.apiPayload.CustomException;
+import com.vitacheck.global.apiPayload.code.ErrorCode;
+import com.vitacheck.repository.NotificationSettingsRepository;
+import com.vitacheck.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationSettingsService {
+
+    private final NotificationSettingsRepository notificationSettingsRepository;
+    private final UserRepository userRepository;
+
+    public List<NotificationSettingsDto> getNotificationSettings(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<NotificationSettings> settings = notificationSettingsRepository.findByUser(user);
+
+        // 사용자의 설정값이 DB에 없으면, 기본값(모두 true)을 생성하여 저장
+        if (settings.isEmpty()) {
+            return createDefaultSettingsForUser(user);
+        }
+        return settings.stream()
+                .map(NotificationSettingsDto::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void updateNotificationSetting(Long userId, NotificationSettingsDto.UpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        NotificationSettings setting = notificationSettingsRepository
+                .findByUserAndTypeAndChannel(user, request.getType(), request.getChannel())
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REQUEST)); // 존재하지 않는 설정을 변경하려는 경우
+
+        setting.setIsEnabled(request.isEnabled());
+    }
+
+    @Transactional
+    public List<NotificationSettingsDto> createDefaultSettingsForUser(User user) {
+        List<NotificationSettings> defaultSettings = Arrays.stream(NotificationType.values())
+                .flatMap(type -> Arrays.stream(NotificationChannel.values())
+                        .map(channel -> NotificationSettings.builder()
+                                .user(user)
+                                .type(type)
+                                .channel(channel)
+                                .isEnabled(true) // 기본값은 모두 ON
+                                .build()))
+                .collect(Collectors.toList());
+
+        notificationSettingsRepository.saveAll(defaultSettings);
+
+        return defaultSettings.stream()
+                .map(NotificationSettingsDto::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/vitacheck/service/RoutineQueryService.java
+++ b/src/main/java/com/vitacheck/service/RoutineQueryService.java
@@ -1,6 +1,6 @@
 package com.vitacheck.service;
 
-import com.vitacheck.domain.NotificationRoutine;
+import com.vitacheck.domain.notification.NotificationRoutine;
 import com.vitacheck.dto.RoutineResponseDto;
 import com.vitacheck.repository.NotificationRoutineRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/vitacheck/service/NotificationSchedulerTest.java
+++ b/src/test/java/com/vitacheck/service/NotificationSchedulerTest.java
@@ -1,6 +1,6 @@
 package com.vitacheck.service;
 
-import com.vitacheck.domain.NotificationRoutine;
+import com.vitacheck.domain.notification.NotificationRoutine;
 import com.vitacheck.domain.RoutineDayOfWeek;
 import com.vitacheck.domain.Supplement;
 import com.vitacheck.domain.user.User;


### PR DESCRIPTION
Close #71 

## ## 📝 작업 내용
사용자가 직접 알림 수신 여부를 종류(이벤트/섭취)와 채널(푸시/문자/이메일)별로 설정할 수 있는 기능을 구현합니다. 

이 기능은 ERD 와 기획 화면 을 기반으로 하며, FCM 푸시 알림을 보낼 때 사용자의 선택을 존중하도록 기존 스케줄러 로직을 수정합니다.

## ## ✅ 변경 사항
- **알림 설정 도메인 모델 추가**
  - `NotificationType`, `NotificationChannel` Enum을 생성했습니다.
  - `User`와 연관 관계를 맺는 `NotificationSettings` 엔티티를 추가했습니다.

- **알림 설정 API 구현**
  - `NotificationSettingsDto`를 추가하여 API 요청/응답에 사용합니다.
  - `NotificationSettingsRepository`를 추가하여 DB 작업을 처리합니다.
  - `NotificationSettingsService`를 구현했습니다.
    - 사용자의 설정 값이 없을 경우, 모든 알림을 활성화하는 기본값을 생성합니다.
    - 사용자의 알림 설정을 조회하고 수정하는 로직을 포함합니다.
  - `NotificationSettingsController`를 추가했습니다.
    - `GET /api/v1/notification-settings/me`: 내 알림 설정 조회 API
    - `PUT /api/v1/notification-settings/me`: 내 알림 설정 변경 API

- **기존 기능과 통합**
  - `NotificationScheduler`가 알림을 발송하기 전에 `NotificationSettingsRepository`를 조회하여, 사용자가 '섭취(INTAKE)' 알림을 '푸시(PUSH)'로 받도록 설정했는지 확인하는 로직을 추가했습니다.


## ## 💬 리뷰어에게
사용자별 알림 설정 기능의 백엔드 구현이 완료되었습니다.

`NotificationSettingsService`에서 처음 설정이 없는 유저에게 기본값을 생성해주는 로직과, `NotificationScheduler`에서 사용자의 동의 여부를 확인하는 부분을 중점적으로 리뷰해주시면 감사하겠습니다.