### PR TITLE
Fix(#79): 빌드 환경 표준화 및 FCM 키 관리 개선으로 배포 실패 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,8 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4' // 혹은 최신 안정 버전
 
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4' // fcm-key 연결용
 }
 
 // Q-Type 클래스 생성 위치 지정

--- a/src/main/java/com/vitacheck/config/FirebaseConfig.java
+++ b/src/main/java/com/vitacheck/config/FirebaseConfig.java
@@ -4,12 +4,19 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.vitacheck.global.apiPayload.CustomException;
+import com.vitacheck.global.apiPayload.code.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StringUtils;
 
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -19,13 +26,44 @@ import java.util.List;
 @Profile("!test")
 public class FirebaseConfig {
 
+    // prod 환경에서 사용
+    @Value("${firebase.key-json:#{null}}")
+    private String fcmKeyJson;
+
+    // local 환경에서 사용
+    @Value("${firebase.key-path:#{null}}")
+    private String fcmKeyPath;
+
     // 이 Bean이 생성될 때 FirebaseApp 초기화를 먼저 수행합니다.
     @Bean
     public FirebaseApp firebaseApp() throws IOException {
         log.info("FirebaseApp 초기화를 시작합니다...");
 
-        ClassPathResource resource = new ClassPathResource("firebase-service-account-key.json");
-        InputStream serviceAccount = resource.getInputStream();
+        InputStream serviceAccount;
+
+        // 1. prod 환경
+        if (StringUtils.hasText(fcmKeyJson)) {
+            log.info("Secrets Manager 키를 사용해 Firebase 초기화");
+            serviceAccount = new ByteArrayInputStream(fcmKeyJson.getBytes());
+        }
+
+        // 2. local 환경
+        else if (StringUtils.hasText(fcmKeyPath)) {
+            log.info("로컬 파일 경로({})를 사용해 Firebase를 초기화", fcmKeyPath);
+            /*
+            Resource resource = new ClassPathResource(fcmKeyPath);
+            if (!resource.exists()) {
+                throw new CustomException(ErrorCode.FCM_FILE_NOT_FOUND);
+            }
+
+             */
+            serviceAccount = new FileInputStream(fcmKeyPath);
+        }
+
+        // 3. 둘 다 없는 경우
+        else {
+            throw new CustomException(ErrorCode.FCM_CONFIG_NOT_FOUND);
+        }
 
         List<FirebaseApp> firebaseApps = FirebaseApp.getApps();
         if (firebaseApps != null && !firebaseApps.isEmpty()) {
@@ -47,7 +85,6 @@ public class FirebaseConfig {
     }
 
     // 위에서 생성된 FirebaseApp Bean을 주입받아 FirebaseMessaging Bean을 생성합니다.
-    // 이렇게 하면 항상 초기화가 완료된 후에 이 메소드가 호출됩니다.
     @Bean
     public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
         return FirebaseMessaging.getInstance(firebaseApp);

--- a/src/main/java/com/vitacheck/domain/Brand.java
+++ b/src/main/java/com/vitacheck/domain/Brand.java
@@ -23,5 +23,6 @@ public class Brand extends BaseTimeEntity {
     private String name;
 
     @OneToMany(mappedBy = "brand")
+    @Builder.Default
     private List<Supplement> supplements = new ArrayList<>();
 }

--- a/src/main/java/com/vitacheck/domain/Supplement.java
+++ b/src/main/java/com/vitacheck/domain/Supplement.java
@@ -48,6 +48,7 @@ public class Supplement extends BaseTimeEntity {
     private LocalDateTime createdAt;
 
     // 영양제(1) <-> 영양제-성분(N)
+    @Builder.Default
     @OneToMany(mappedBy = "supplement", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SupplementIngredient> supplementIngredients = new ArrayList<>();
 }

--- a/src/main/java/com/vitacheck/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/vitacheck/global/apiPayload/code/ErrorCode.java
@@ -31,7 +31,12 @@ public enum ErrorCode implements BaseErrorCode {
 
     // 복용 루틴
     DUPLICATED_ROUTINE("R0001", "이미 등록된 복용 루틴입니다.", HttpStatus.CONFLICT),
-    ROUTINE_NOT_FOUND("R0002", "복용 루틴을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    ROUTINE_NOT_FOUND("R0002", "복용 루틴을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    // FCM 관련
+    FCM_CONFIG_NOT_FOUND("F0001", "FCM 설정(키 파일 경로 또는 JSON 값)을 찾을 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    FCM_FILE_NOT_FOUND("F0002", "지정된 경로에서 FCM 키 파일을 찾을 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
 
     private final String code;
     private final String message;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,6 +4,8 @@ spring:
     url: jdbc:mysql://${PROD_DB_ENDPOINT}:3306/vitacheck?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
     username: ${PROD_DB_USERNAME}
     password: ${PROD_DB_PASSWORD}
+  config:
+    import: "aws-secretsmanager:vitacheck/fcm-key"
   security:
     oauth2:
       client:
@@ -29,6 +31,7 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+
   jpa:
     hibernate:
       ddl-auto: none # 운영 환경에서는 validate 또는 none 사용


### PR DESCRIPTION
Close #79 

## 📝 작업 내용
CI/CD 배포 시 firebase-service-account-key.json 파일을 찾지 못해 서버가 구동되지 않는 문제를 해결했습니다.

IntelliJ와 Gradle의 빌드 불일치로 인해 리소스 파일이 누락되는 현상이 근본 원인이었으며, 이를 해결하기 위해 빌드 및 실행 환경을 Gradle 기준으로 표준화했습니다. 또한, 운영 환경의 FCM 키 관리를 위해 AWS Secrets Manager를 도입하여 보안을 강화하고 로컬 개발 환경 설정을 분리했습니다.

## ✅ 변경 사항
[x] IntelliJ 빌드 환경 표준화

모든 빌드 및 실행 작업을 IntelliJ IDEA가 아닌 Gradle에 위임하도록 설정을 변경했습니다.

build.gradle에 sourceSets 및 clean task를 추가하여 QueryDSL Q-File 생성 오류 및 리소스 누락 문제를 해결했습니다.

[x] Firebase 키 관리 방식 변경

운영 환경: AWS Secrets Manager를 사용하도록 spring-cloud-starter-aws-secrets-manager-config 의존성을 추가하고, application-prod.yml에 관련 설정을 추가했습니다.

로컬 환경: application-local.yml을 신규 생성하여 로컬 전용 설정을 분리하고, 프로젝트 최상위 경로에서 firebase-service-account-key.json 파일을 직접 읽도록 수정했습니다.

[x] Lombok @Builder 경고 수정

Supplement, Brand 엔티티의 List 필드에 @Builder.Default를 추가하여 빌드 경고를 해결했습니다.

## 💬 리뷰어에게
이번 변경으로 팀의 개발 환경이 표준화되었습니다. develop 브랜치를 pull 받으신 후, 로컬 서버를 실행하기 위해 아래 가이드를 꼭 진행해주세요!

1. IntelliJ 설정 변경 (최초 1회)

IntelliJ IDEA > Settings(Preferences) > Build, Execution, Deployment > Build Tools > Gradle 로 이동

Build and run using 과 Run tests using 항목을 모두 Gradle 로 변경해주세요.

2. firebase-service-account-key.json 파일 위치 변경

기존에 src/main/resources에 있던 키 파일을 프로젝트 최상위 폴더(.gitignore 파일과 같은 위치)로 이동해주세요.

위 두 가지 설정 후 Gradle 새로고침 한번 해주시면 바로 정상적으로 실행됩니다. 앞으로는 더 안정적인 환경에서 개발할 수 있을 거예요!