### PR TITLE
feature: #64 사용자가 선택한 목적에 맞는 영양소와 그를 포함하는 영양제 목록 반환 POST API 제작

### DIFF
--- a/src/main/generated/com/vitacheck/domain/QIngredient.java
+++ b/src/main/generated/com/vitacheck/domain/QIngredient.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.*;
 import com.querydsl.core.types.PathMetadata;
 import javax.annotation.processing.Generated;
 import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
 
 
 /**
@@ -26,6 +27,8 @@ public class QIngredient extends EntityPathBase<Ingredient> {
     public final StringPath name = createString("name");
 
     public final NumberPath<Integer> recommendedDosage = createNumber("recommendedDosage", Integer.class);
+
+    public final ListPath<com.vitacheck.domain.mapping.SupplementIngredient, com.vitacheck.domain.mapping.QSupplementIngredient> supplementIngredients = this.<com.vitacheck.domain.mapping.SupplementIngredient, com.vitacheck.domain.mapping.QSupplementIngredient>createList("supplementIngredients", com.vitacheck.domain.mapping.SupplementIngredient.class, com.vitacheck.domain.mapping.QSupplementIngredient.class, PathInits.DIRECT2);
 
     public final StringPath unit = createString("unit");
 

--- a/src/main/java/com/vitacheck/controller/SupplementController.java
+++ b/src/main/java/com/vitacheck/controller/SupplementController.java
@@ -1,6 +1,8 @@
 package com.vitacheck.controller;
 
+import com.vitacheck.dto.SupplementByPurposeResponse;
 import com.vitacheck.dto.SupplementDto;
+import com.vitacheck.dto.SupplementPurposeRequest;
 import com.vitacheck.global.apiPayload.CustomException;
 import com.vitacheck.global.apiPayload.CustomResponse;
 import com.vitacheck.global.apiPayload.code.ErrorCode;
@@ -10,13 +12,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,5 +44,13 @@ public class SupplementController {
         List<SupplementDto.SearchResponse> response = supplementService.search(keyword, brandName, ingredientName);
 
         return CustomResponse.ok(response);
+    }
+
+    @PostMapping("/by-purposes")
+    @Operation(summary = "목적별 영양소 및 영양제 조회", description = "선택한 목적에 맞는 성분 및 관련 영양제를 반환합니다.")
+    public ResponseEntity<Map<String, SupplementByPurposeResponse>> getSupplementsByPurposes(
+            @RequestBody SupplementPurposeRequest request
+    ) {
+        return ResponseEntity.ok(supplementService.getSupplementsByPurposes(request));
     }
 }

--- a/src/main/java/com/vitacheck/domain/Ingredient.java
+++ b/src/main/java/com/vitacheck/domain/Ingredient.java
@@ -1,9 +1,13 @@
 package com.vitacheck.domain;
 
+import com.vitacheck.domain.mapping.SupplementIngredient;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "ingredients")
@@ -27,4 +31,7 @@ public class Ingredient {
 
     @Column(nullable = false, length = 20)
     private String unit;
+
+    @OneToMany(mappedBy = "ingredient", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SupplementIngredient> supplementIngredients = new ArrayList<>();
 }

--- a/src/main/java/com/vitacheck/domain/mapping/IngredientCategory.java
+++ b/src/main/java/com/vitacheck/domain/mapping/IngredientCategory.java
@@ -1,0 +1,29 @@
+package com.vitacheck.domain.mapping;
+
+import com.vitacheck.domain.Ingredient;
+import com.vitacheck.domain.purposes.PurposeCategory;
+import jakarta.persistence.*;
+import lombok.*;
+
+// 목적(카테고리) - 영양성분 매핑테이블
+@Entity
+@Table(name = "ingredient_categories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class IngredientCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ingredient_id", nullable = false)
+    private Ingredient ingredient;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private PurposeCategory category;
+}
+

--- a/src/main/java/com/vitacheck/domain/purposes/PurposeCategory.java
+++ b/src/main/java/com/vitacheck/domain/purposes/PurposeCategory.java
@@ -1,0 +1,36 @@
+package com.vitacheck.domain.purposes;
+
+import com.vitacheck.domain.Ingredient;
+import com.vitacheck.domain.mapping.IngredientCategory;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// AllPurpose의 DB 엔티티화
+@Entity
+@Table(name = "purpose_categories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PurposeCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Enum으로 저장됨 -> 목적 이름
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, unique = true)
+    private AllPurpose name;
+
+    private String imageUrl;
+
+    private Integer displayOrder; // 정렬 순서
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<IngredientCategory> ingredientCategories = new ArrayList<>();
+}

--- a/src/main/java/com/vitacheck/dto/SupplementByPurposeResponse.java
+++ b/src/main/java/com/vitacheck/dto/SupplementByPurposeResponse.java
@@ -1,0 +1,16 @@
+package com.vitacheck.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class SupplementByPurposeResponse {
+    private List<String> purposes; // 해당 성분이 속한 목적들
+    private List<List<String>> supplements; // [영양제 이름, 이미지 URL]
+}
+

--- a/src/main/java/com/vitacheck/dto/SupplementPurposeRequest.java
+++ b/src/main/java/com/vitacheck/dto/SupplementPurposeRequest.java
@@ -1,0 +1,11 @@
+package com.vitacheck.dto;
+
+import lombok.Getter;
+import java.util.List;
+
+// 사용자로부터 목적을 ENUM으로 받아온다
+@Getter
+public class SupplementPurposeRequest {
+    private List<String> purposeNames;
+}
+

--- a/src/main/java/com/vitacheck/repository/PurposeCategoryRepository.java
+++ b/src/main/java/com/vitacheck/repository/PurposeCategoryRepository.java
@@ -1,0 +1,13 @@
+package com.vitacheck.repository;
+
+import com.vitacheck.domain.purposes.PurposeCategory;
+import com.vitacheck.domain.purposes.AllPurpose;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PurposeCategoryRepository extends JpaRepository<PurposeCategory, Long> {
+    Optional<PurposeCategory> findByName(AllPurpose name);
+    List<PurposeCategory> findAllByNameIn(List<AllPurpose> names);
+}

--- a/src/main/java/com/vitacheck/service/SupplementService.java
+++ b/src/main/java/com/vitacheck/service/SupplementService.java
@@ -1,13 +1,21 @@
 package com.vitacheck.service;
 
+import com.vitacheck.domain.Ingredient;
 import com.vitacheck.domain.Supplement;
+import com.vitacheck.domain.mapping.IngredientCategory;
+import com.vitacheck.domain.mapping.SupplementIngredient;
+import com.vitacheck.domain.purposes.AllPurpose;
+import com.vitacheck.domain.purposes.PurposeCategory;
+import com.vitacheck.dto.SupplementByPurposeResponse;
 import com.vitacheck.dto.SupplementDto;
+import com.vitacheck.dto.SupplementPurposeRequest;
+import com.vitacheck.repository.PurposeCategoryRepository;
 import com.vitacheck.repository.SupplementRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -16,6 +24,7 @@ import java.util.stream.Collectors;
 public class SupplementService {
 
     private final SupplementRepository supplementRepository;
+    private final PurposeCategoryRepository purposeCategoryRepository;
 
     public List<SupplementDto.SearchResponse> search(String keyword, String brandName, String ingredientName) {
         List<Supplement> supplements = supplementRepository.search(keyword, brandName, ingredientName);
@@ -23,5 +32,48 @@ public class SupplementService {
         return supplements.stream()
                 .map(SupplementDto.SearchResponse::from)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public Map<String, SupplementByPurposeResponse> getSupplementsByPurposes(SupplementPurposeRequest request) {
+        List<AllPurpose> allPurposes = request.getPurposeNames().stream()
+                .map(AllPurpose::valueOf)
+                .toList();
+
+        List<PurposeCategory> categories = purposeCategoryRepository.findAllByNameIn(allPurposes);
+
+        // 성분 -> 목적 리스트 매핑
+        Map<Ingredient, Set<String>> ingredientToPurposes = new HashMap<>();
+
+        for (PurposeCategory category : categories) {
+            String purposeDesc = category.getName().getDescription();
+            for (IngredientCategory ic : category.getIngredientCategories()) {
+                Ingredient ingredient = ic.getIngredient();
+                ingredientToPurposes
+                        .computeIfAbsent(ingredient, k -> new HashSet<>())
+                        .add(purposeDesc);
+            }
+        }
+
+        Map<String, SupplementByPurposeResponse> result = new HashMap<>();
+
+        for (Map.Entry<Ingredient, Set<String>> entry : ingredientToPurposes.entrySet()) {
+            Ingredient ingredient = entry.getKey();
+            Set<String> purposes = entry.getValue();
+
+            List<List<String>> supplementInfo = ingredient.getSupplementIngredients().stream()
+                    .map(SupplementIngredient::getSupplement)
+                    .map(supplement -> List.of(supplement.getName(), supplement.getImageUrl()))
+                    .toList();
+
+            result.put(ingredient.getName(),
+                    SupplementByPurposeResponse.builder()
+                            .purposes(new ArrayList<>(purposes))
+                            .supplements(supplementInfo)
+                            .build()
+            );
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
Close #64 

## 📝 작업 내용
사용자가 선택한 목적에 맞는 영양소 및 이를 포함하는 영양제 목록을 반환하는 API를 제작하였습니다.
 
## ✅ 변경 사항
- mapping 테이블에 IngredientCategory 추가 
- PurposeCategory 엔티티 추가
- Ingredient 테이블에 SupplementIngredient (중간)테이블과의 OneToMany 연관관계 추가
- Supplement Service에 목적 기반 영양소 조회 + 영양제 목록 구성 로직 추가 
- 그 외 레포지토리, DTO 등 추가 
- 필터 제외 목록에 엔트포인트 잠시 추가하여 통신 결과 테스트 완료 

## 📷 스크린샷 (선택)
<img width="1030" height="1293" alt="image" src="https://github.com/user-attachments/assets/7ae77abb-1349-4ce9-b866-68beb56e58e3" />
