### PR TITLE
feat(#95): 사용자 조회 API에 나이 추가

### DIFF
--- a/src/main/java/com/vitacheck/dto/UserDto.java
+++ b/src/main/java/com/vitacheck/dto/UserDto.java
@@ -90,6 +90,7 @@ public class UserDto {
         private String nickname;
         private String fullName;
         private String provider;
+        private int age;
     }
 
     @Getter

--- a/src/main/java/com/vitacheck/service/UserService.java
+++ b/src/main/java/com/vitacheck/service/UserService.java
@@ -13,7 +13,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Period;
 
 @Service
 @Transactional(readOnly = true)
@@ -92,7 +94,18 @@ public class UserService {
     public UserDto.InfoResponse getMyInfo(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        return new UserDto.InfoResponse(user.getEmail(), user.getNickname(), user.getFullName(), user.getProvider());
+
+        int age = 0; // 기본값
+        if (user.getBirthDate() != null) {
+            age = Period.between(user.getBirthDate(), LocalDate.now()).getYears();
+        }
+        return new UserDto.InfoResponse(
+                user.getEmail(),
+                user.getNickname(),
+                user.getFullName(),
+                user.getProvider(),
+                age
+        );
     }
 
     @Transactional
@@ -100,7 +113,19 @@ public class UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         user.updateNickname(request.getNickname());
-        return new UserDto.InfoResponse(user.getEmail(), user.getNickname(), user.getFullName(), user.getProvider());
+
+        int age = 0; // 기본값
+        if (user.getBirthDate() != null) {
+            age = Period.between(user.getBirthDate(), LocalDate.now()).getYears();
+        }
+
+        return new UserDto.InfoResponse(
+                user.getEmail(),
+                user.getNickname(),
+                user.getFullName(),
+                user.getProvider(),
+                age
+        );
     }
 
     public Long findIdByEmail(String email) {


### PR DESCRIPTION
Close #95 

## ## 📝 작업 내용
사용자 정보 조회 API 응답에 '나이' 필드를 추가했습니다.
/api/v1/users/me (GET, PUT) 엔드포인트에서 사용자의 생년월일(birthDate)을 기반으로 만 나이를 계산하여 반환합니다.

## ## ✅ 변경 사항
사용자 나이 정보 추가
- dto/UserDto.java
InfoResponse DTO에 age (int) 필드를 추가했습니다.

- service/UserService.java
getMyInfo, updateMyInfo 메소드에 Period.between()을 사용하여 만 나이를 계산하는 로직을 추가하고, InfoResponse에 담아 반환하도록 수정했습니다.