### PR TITLE
refactor(#100): 목적별 영양소/영양제 목록 POST API N+1 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,24 +68,16 @@ dependencies {
 }
 
 // Q-Type 클래스 생성 위치 지정
-def generatedDir = 'src/main/generated'
+def querydslDir = "$buildDir/generated/querydsl"
 
 sourceSets {
-    main {
-        java {
-            srcDirs += [ generatedDir ]
-        }
-    }
+    main.java.srcDirs += querydslDir
 }
 
-tasks.withType(JavaCompile) {
-    options.getGeneratedSourceOutputDirectory().set(file(generatedDir))
+tasks.withType(JavaCompile).configureEach {
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
 }
 
 clean {
-    delete file(generatedDir)
-}
-
-tasks.named('test') {
-    useJUnitPlatform()
+    delete file(querydslDir)
 }

--- a/src/main/java/com/vitacheck/repository/PurposeCategoryQueryRepository.java
+++ b/src/main/java/com/vitacheck/repository/PurposeCategoryQueryRepository.java
@@ -1,0 +1,10 @@
+package com.vitacheck.repository;
+
+import com.vitacheck.domain.purposes.AllPurpose;
+import com.vitacheck.domain.purposes.PurposeCategory;
+
+import java.util.List;
+
+public interface PurposeCategoryQueryRepository {
+    List<PurposeCategory> findAllWithIngredientAndSupplementByNameIn(List<AllPurpose> names);
+}

--- a/src/main/java/com/vitacheck/repository/PurposeCategoryQueryRepositoryImpl.java
+++ b/src/main/java/com/vitacheck/repository/PurposeCategoryQueryRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.vitacheck.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.vitacheck.domain.QIngredient;
+import com.vitacheck.domain.QSupplement;
+import com.vitacheck.domain.mapping.QIngredientCategory;
+import com.vitacheck.domain.mapping.QSupplementIngredient;
+import com.vitacheck.domain.purposes.AllPurpose;
+import com.vitacheck.domain.purposes.PurposeCategory;
+import com.vitacheck.domain.purposes.QPurposeCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PurposeCategoryQueryRepositoryImpl implements PurposeCategoryQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<PurposeCategory> findAllWithIngredientAndSupplementByNameIn(List<AllPurpose> names) {
+        QPurposeCategory pc = QPurposeCategory.purposeCategory;
+        QIngredientCategory ic = QIngredientCategory.ingredientCategory;
+        QIngredient i = QIngredient.ingredient;
+        QSupplementIngredient si = QSupplementIngredient.supplementIngredient;
+        QSupplement s = QSupplement.supplement;
+
+        return queryFactory
+                .selectFrom(pc)
+                .distinct()
+                .join(pc.ingredientCategories, ic).fetchJoin()
+                .join(ic.ingredient, i).fetchJoin()
+                .join(i.supplementIngredients, si).fetchJoin()
+                .join(si.supplement, s).fetchJoin()
+                .where(pc.name.in(names))
+                .fetch();
+    }
+}
+

--- a/src/main/java/com/vitacheck/repository/PurposeCategoryRepository.java
+++ b/src/main/java/com/vitacheck/repository/PurposeCategoryRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface PurposeCategoryRepository extends JpaRepository<PurposeCategory, Long> {
+public interface PurposeCategoryRepository extends JpaRepository<PurposeCategory, Long>, PurposeCategoryQueryRepository {
     Optional<PurposeCategory> findByName(AllPurpose name);
     List<PurposeCategory> findAllByNameIn(List<AllPurpose> names);
 }


### PR DESCRIPTION
Close #100 

## 📝 작업 내용
목적별 영양소/영양제 목록 POST API에서 발생하던 N+1 가능성을 수정하였습니다.
QueryDsl을 이용하여 쿼리를 작성하여, LAZY 설정으로 인한 N+1 우려를 없앴습니다.

## ✅ 변경 사항
- [x] QueryDsl Q 클래스 생성 위치 등 gradle 파일 일부 수정 (하단)
- [x] PurposeCategoryQueryRepository 생성
- [x] PurposeCategoryQueryRepositoryImpl 생성
```
 return queryFactory
                .selectFrom(pc)
                .distinct()
                .join(pc.ingredientCategories, ic).fetchJoin()
                .join(ic.ingredient, i).fetchJoin()
                .join(i.supplementIngredients, si).fetchJoin()
                .join(si.supplement, s).fetchJoin()
                .where(pc.name.in(names))
                .fetch();
```
- [x] QueryDsl로 새로 작성한 findAllWithIngredientAndSupplementByNameIn 메소드로 기존의 메소드 대체하여 문제 해결
