### PR TITLE
feat(#77) 성분의 상세 정보 조회 api 추가

### DIFF
--- a/src/main/java/com/vitacheck/config/SecurityConfig.java
+++ b/src/main/java/com/vitacheck/config/SecurityConfig.java
@@ -44,7 +44,9 @@ public class SecurityConfig {
             // 기타
             "/error",
             "/fcm_test.html",
-            "/firebase-messaging-sw.js"
+            "/firebase-messaging-sw.js",
+            //성분
+            "/api/ingredients/**"
     };
 
     @Bean

--- a/src/main/java/com/vitacheck/controller/IngredientController.java
+++ b/src/main/java/com/vitacheck/controller/IngredientController.java
@@ -1,0 +1,31 @@
+package com.vitacheck.controller;
+
+import com.vitacheck.domain.Ingredient;
+import com.vitacheck.dto.IngredientResponseDTO;
+import com.vitacheck.global.apiPayload.CustomResponse;
+import com.vitacheck.service.IngredientService;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+public class IngredientController {
+    private final IngredientService ingredientService;
+
+    @Operation(
+            summary = "성분 상세 조회 API By 박지영",
+            description = """
+        성분의 설명, 효능, 부작용 및 주의사항, 상한 섭취량, 하한 섭취량 등을 반환합니다..
+        """
+
+    )
+    @GetMapping("/api/ingredients/{id}")
+    public CustomResponse<IngredientResponseDTO.IngredientDetails> getIngredientDetails(@PathVariable Long id) {
+        IngredientResponseDTO.IngredientDetails responseDto = ingredientService.getIngredientDetails(id);
+        return CustomResponse.ok(responseDto);
+    }
+
+}

--- a/src/main/java/com/vitacheck/domain/Ingredient.java
+++ b/src/main/java/com/vitacheck/domain/Ingredient.java
@@ -5,7 +5,11 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,24 +17,41 @@ import java.util.List;
 @Table(name = "ingredients")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Ingredient {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 50)
+    @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(columnDefinition = "TEXT")
+    @Column(name = "description",columnDefinition = "TEXT")
     private String description;
 
-    private Integer recommendedDosage;
+    @Column(name = "caution",columnDefinition = "TEXT")
+    private String caution;
 
-    private Integer upperLimit;
+    @Column(name = "effect",columnDefinition = "TEXT")
+    private String effect;
 
-    @Column(nullable = false, length = 20)
+    @Column(name = "lower_limit")
+    private Double lowerLimit;
+
+    @Column(name = "upper_limit")
+    private Double upperLimit;
+
+    @Column(name = "unit", length = 20)
     private String unit;
+
+    @Column(name = "created_at")
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "ingredient", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SupplementIngredient> supplementIngredients = new ArrayList<>();

--- a/src/main/java/com/vitacheck/dto/IngredientResponseDTO.java
+++ b/src/main/java/com/vitacheck/dto/IngredientResponseDTO.java
@@ -1,0 +1,59 @@
+package com.vitacheck.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IngredientResponseDTO {
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class IngredientDetails{
+        private Long id;
+        private String name;
+        private String description;    // 설명
+        private String effect;         // 효능
+        private String caution;        // 부작용 및 주의사
+        private Double upper_limit;     // 상한
+        private Double lower_limit;     // 하한
+        private String unit;           // 단위
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class IngredientSupplement{
+        private Long id;
+        private String name;
+        private List<SubIngredient> subIngredients = new ArrayList<>();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class IngredientFood{
+        private Long id;
+        private String name;
+        private List<SubIngredient> subIngredients = new ArrayList<>();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class SubIngredient {
+        private String name;
+        private String imageOrEmoji;  // 이미지 URL 또는 이모지 표현
+    }
+
+
+}
+
+

--- a/src/main/java/com/vitacheck/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/vitacheck/global/apiPayload/code/ErrorCode.java
@@ -35,8 +35,10 @@ public enum ErrorCode implements BaseErrorCode {
 
     // FCM 관련
     FCM_CONFIG_NOT_FOUND("F0001", "FCM 설정(키 파일 경로 또는 JSON 값)을 찾을 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    FCM_FILE_NOT_FOUND("F0002", "지정된 경로에서 FCM 키 파일을 찾을 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    FCM_FILE_NOT_FOUND("F0002", "지정된 경로에서 FCM 키 파일을 찾을 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
 
+    // 성분 관련
+    INGREDIENT_NOT_FOUND("INGREDIENT404_0","해당 성분이 존재하지 않습니다.",HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/vitacheck/repository/IngredientRepository.java
+++ b/src/main/java/com/vitacheck/repository/IngredientRepository.java
@@ -1,0 +1,10 @@
+package com.vitacheck.repository;
+
+import com.vitacheck.domain.Ingredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+    Optional<Ingredient> findById(Long id);
+}

--- a/src/main/java/com/vitacheck/service/IngredientService.java
+++ b/src/main/java/com/vitacheck/service/IngredientService.java
@@ -1,0 +1,41 @@
+package com.vitacheck.service;
+
+import com.vitacheck.domain.Ingredient;
+import com.vitacheck.dto.IngredientResponseDTO;
+import com.vitacheck.global.apiPayload.CustomException;
+import com.vitacheck.global.apiPayload.code.ErrorCode;
+import com.vitacheck.repository.IngredientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IngredientService {
+    private final IngredientRepository ingredientRepository;
+
+    public IngredientResponseDTO.IngredientDetails getIngredientDetails(Long id) {
+        Ingredient ingredient = ingredientRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.INGREDIENT_NOT_FOUND));
+
+        return IngredientResponseDTO.IngredientDetails.builder()
+                .id(ingredient.getId())
+                .name(ingredient.getName())
+                .description(ingredient.getDescription())
+                .effect(ingredient.getEffect())
+                .caution(ingredient.getCaution())
+                .upper_limit(ingredient.getUpperLimit())
+                .lower_limit(ingredient.getLowerLimit())
+                .unit(ingredient.getUnit())
+                .build();
+
+    }
+
+//    public IngredientFood getIngredientFoods(Long id) {
+//        if (!ingredientRepository.existsById(id)) {
+//            throw new CustomException(ErrorCode.INGREDIENT_NOT_FOUND);
+//        }
+//        List<IngredientAlternativeFood> foods = foodRepository.findByIngredientId(id);
+//        return IngredientConverter.toFoodDto(id, foods);
+//    }
+
+}


### PR DESCRIPTION
related to #77 

## ## 📝 작업 내용
성분의 상세 정보 조회 api 추가
(성분 관련 기본적인 dto, repository, service, controller 추가)

## ## ✅ 변경 사항
- [x] Ingredients의 엔티티 수정 (현재 erd cloud 기준으로 수정함)
- [x] errorcode에 "INGREDIENT_NOT_FOUND" 추가
- [x] securityconfig에 "/api/ingredients/**" 추가

## ## 📷 스크린샷 (선택)
1) Ingredient 엔티티
<img width="514" height="198" alt="image" src="https://github.com/user-attachments/assets/085d1ede-0aed-4441-bb66-a20722aeda9f" />

2) swagger에서 api 동작 확인
<img width="612" height="259" alt="image" src="https://github.com/user-attachments/assets/249ee2f4-8c46-496f-9c69-1744b3108d15" />
<img width="613" height="318" alt="image" src="https://github.com/user-attachments/assets/7d9dadbf-7a82-4331-84a2-663dcbf831da" />


## ## 💬 리뷰어에게
swagger를 통해 성공,실패 응답 확인했습니다. (추가 예외 처리는 추후 진행 예정입니다.)
```diff
SecurityConfig, ErrorCode 등은 다른 도메인들도 사용할 수 있는 공통 파일입니다. 
수정 시 톡방을 통해 미리 고지 하는 것이 좋을 것 같습니다.