### PR TITLE
fix(#104): UserDto 중복 클래스 문제 해결

### DIFF
--- a/src/main/java/com/vitacheck/dto/IngredientResponseDTO.java
+++ b/src/main/java/com/vitacheck/dto/IngredientResponseDTO.java
@@ -31,6 +31,7 @@ public class IngredientResponseDTO {
     public static class IngredientSupplement{
         private Long id;
         private String name;
+        @Builder.Default
         private List<SubIngredient> subIngredients = new ArrayList<>();
     }
 
@@ -41,6 +42,7 @@ public class IngredientResponseDTO {
     public static class IngredientFood{
         private Long id;
         private String name;
+        @Builder.Default
         private List<SubIngredient> subIngredients = new ArrayList<>();
     }
 

--- a/src/main/java/com/vitacheck/dto/UserDto.java
+++ b/src/main/java/com/vitacheck/dto/UserDto.java
@@ -98,10 +98,4 @@ public class UserDto {
     public static class UpdateFcmTokenRequest {
         private String fcmToken;
     }
-
-    @Getter
-    @NoArgsConstructor
-    public static class UpdateFcmTokenRequest {
-        private String fcmToken;
-    }
 }


### PR DESCRIPTION
Close #104 

## 📝 작업 내용
프로젝트의 정상적인 실행을 방해하던 빌드 오류들을 일부 해결했습니다.

UserDto 내부에 중복으로 선언된 클래스를 제거하여 컴파일 오류를 수정했습니다.

Lombok @Builder 사용 시 컬렉션 필드가 null로 초기화되는 문제를 수정했습니다.

## ✅ 변경 사항
UserDto.java

[x] 내부에 중복으로 선언되었던 UpdateFcmTokenRequest 클래스를 제거했습니다.

IngredientResponseDTO.java

[x] @Builder 사용 시 subIngredients 리스트가 정상적으로 초기화되도록 @Builder.Default 어노테이션을 추가했습니다.


## 💬 리뷰어에게
이번 PR은 다른 기능의 정상적인 개발을 위해 필수적인 빌드 오류 해결에 초점을 맞췄습니다.
CombinationService 로직은 제 파트가 아니어서 직접 수정하지는 않았습니다. 다만, 빌드 오류를 해결하는 과정에서 Ingredient 엔티티의 필드 타입 등이 변경되었으니, CombinationService 파트 담당자분께서는 해당 변경 사항이 로직에 영향을 주지 않는지 확인 부탁드립니다.
@minHorang 