### PR TITLE
fix(#114): JwtAuthenticationFilter 클래스 인증 오류 수정

### DIFF
--- a/src/main/java/com/vitacheck/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/vitacheck/config/jwt/JwtAuthenticationFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             UserDetails userDetails = new CustomUserDetails(user);
 
             Authentication authentication = new UsernamePasswordAuthenticationToken(
-                    user, // 👈 Principal로 User 엔티티 객체를 사용
+                    userDetails, // 👈 Principal로 User 엔티티 객체를 사용
                     "",
                     userDetails.getAuthorities());
 


### PR DESCRIPTION
Close #114 

## ## 📝 작업 내용
JWT 인증 필터에서 `@AuthenticationPrincipal`이 null로 들어오는 버그 수정

## ## ✅ 변경 사항
JwtAuthenticationFilter`에서 `UsernamePasswordAuthenticationToken`의 Principal을 `User` → `CustomUserDetails`로 수정
인증된 사용자 정보가 SecurityContext에 정상적으로 등록되도록 처리
Swagger 테스트 시 500 에러 발생 문제 해결

## ## 💬 리뷰어에게
이번 수정으로 Swagger 및 클라이언트에서 JWT 인증 기반 요청 시  
정상적으로 유저 정보가 주입되도록 개선했습니다.  