### PR TITLE
refactor(#116): RoutineRegisterResponseDto, NotificationRoutineCommandService 수정

### DIFF
--- a/src/main/java/com/vitacheck/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/vitacheck/config/jwt/JwtAuthenticationFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             UserDetails userDetails = new CustomUserDetails(user);
 
             Authentication authentication = new UsernamePasswordAuthenticationToken(
-                    user, // 👈 Principal로 User 엔티티 객체를 사용
+                    userDetails, // 👈 Principal로 User 엔티티 객체를 사용
                     "",
                     userDetails.getAuthorities());
 

--- a/src/main/java/com/vitacheck/dto/RoutineRegisterResponseDto.java
+++ b/src/main/java/com/vitacheck/dto/RoutineRegisterResponseDto.java
@@ -19,6 +19,10 @@ public class RoutineRegisterResponseDto {
 
     private Long supplementId;
 
+    private String supplementName;
+
+    private String supplementImageUrl;
+
     private List<RoutineDayOfWeek> daysOfWeek;
 
     private List<LocalTime> times;

--- a/src/main/java/com/vitacheck/service/NotificationRoutineCommandService.java
+++ b/src/main/java/com/vitacheck/service/NotificationRoutineCommandService.java
@@ -74,7 +74,9 @@ public class NotificationRoutineCommandService {
         // 8. 응답 DTO 반환
         return RoutineRegisterResponseDto.builder()
                 .notificationRoutineId(saved.getId())
-                .supplementId(saved.getSupplement().getId())
+                .supplementId(supplement.getId())
+                .supplementName(supplement.getName())
+                .supplementImageUrl(supplement.getImageUrl())
                 .daysOfWeek(saved.getRoutineDays().stream()
                         .map(RoutineDay::getDayOfWeek)
                         .toList())


### PR DESCRIPTION
Close #116 

## ## 📝 작업 내용
루틴 등록 API 응답에 `supplementName`, `supplementImageUrl` 필드를 추가하여 등록 후 프론트에서 바로 영양제 정보를 화면에 표시할 수 있도록 리팩토링

## ## ✅ 변경 사항
- `RoutineRegisterResponseDto`에 `supplementName`, `supplementImageUrl` 필드 추가
- `NotificationRoutineCommandService.registerRoutine()`에서 Supplement 조회 후 DTO에 값 포함

## ## 📷 스크린샷
<img width="624" height="720" alt="image" src="https://github.com/user-attachments/assets/b1688621-00e0-4718-9fc8-37256bd682e5" />


## ## 💬 리뷰어에게
루틴 등록 후 화면에 필요한 정보들이 바로 포함되도록 응답을 확장했습니다. 구조적으로 개선할 부분 있다면 코멘트 부탁드립니다