### PR TITLE
[FEAT] 특정 영양제 상세 정보 반환 API 제작

### DIFF
--- a/src/main/java/com/vitacheck/controller/SupplementController.java
+++ b/src/main/java/com/vitacheck/controller/SupplementController.java
@@ -1,10 +1,7 @@
 package com.vitacheck.controller;
 
 import com.vitacheck.domain.user.User;
-import com.vitacheck.dto.SearchDto;
-import com.vitacheck.dto.SupplementByPurposeResponse;
-import com.vitacheck.dto.SupplementDto;
-import com.vitacheck.dto.SupplementPurposeRequest;
+import com.vitacheck.dto.*;
 import com.vitacheck.global.apiPayload.CustomException;
 import com.vitacheck.global.apiPayload.CustomResponse;
 import com.vitacheck.global.apiPayload.code.ErrorCode;
@@ -77,5 +74,13 @@ public class SupplementController {
             log.info("유저없음");
         }
         return CustomResponse.ok("클릭이 기록되었습니다.");
+    }
+
+    // 특정 영양제 상세 정보 반환 API
+    @GetMapping
+    @Operation(summary = "영양제 상세 조회", description = "supplementId로 상세 정보를 조회합니다.")
+    public SupplementDetailResponseDto getSupplement(@RequestParam Long id,
+                                                     @RequestHeader(name = "X-User-Id") Long userId) {
+        return supplementService.getSupplementDetail(id, userId);
     }
 }

--- a/src/main/java/com/vitacheck/domain/Brand.java
+++ b/src/main/java/com/vitacheck/domain/Brand.java
@@ -22,6 +22,9 @@ public class Brand extends BaseTimeEntity {
     @Column(name = "name", nullable = false, length = 50)
     private String name;
 
+    @Column(name = "image_url", length = 255)
+    private String imageUrl;
+
     @OneToMany(mappedBy = "brand")
     @Builder.Default
     private List<Supplement> supplements = new ArrayList<>();

--- a/src/main/java/com/vitacheck/dto/SupplementDetailResponseDto.java
+++ b/src/main/java/com/vitacheck/dto/SupplementDetailResponseDto.java
@@ -1,0 +1,32 @@
+package com.vitacheck.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+// 영양제 상세 정보 (영양제 이미지, 영양제명, 브랜드명, 브랜드이미지, 쿠팡링크 등) 반환 DTO
+@Getter
+@AllArgsConstructor
+@Builder
+public class SupplementDetailResponseDto {
+
+    private Long supplementId;
+    private String brandName;
+    private String brandImageUrl;
+    private String supplementName;
+    private String supplementImageUrl;
+    private boolean liked;
+    private String coupangLink;
+    private String intakeTime;
+    private List<IngredientDto> ingredients;
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class IngredientDto {
+        private String name;
+        private String amount;
+    }
+}

--- a/src/main/java/com/vitacheck/repository/LikeRepository.java
+++ b/src/main/java/com/vitacheck/repository/LikeRepository.java
@@ -19,4 +19,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     @Query("SELECT l FROM Like l JOIN FETCH l.supplement s JOIN FETCH s.brand WHERE l.user.id = :userId")
     List<Like> findAllByUserIdWithSupplement(@Param("userId") Long userId);
+
+    boolean existsByUserIdAndSupplementId(Long userId, Long supplementId);
 }

--- a/src/main/java/com/vitacheck/repository/SupplementRepository.java
+++ b/src/main/java/com/vitacheck/repository/SupplementRepository.java
@@ -1,13 +1,18 @@
 package com.vitacheck.repository;
 
 import com.vitacheck.domain.Supplement;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SupplementRepository extends JpaRepository<Supplement, Long>, SupplementRepositoryCustom {
     @Query("SELECT s FROM Supplement s JOIN FETCH s.supplementIngredients si JOIN FETCH si.ingredient WHERE s.id IN :ids")
     List<Supplement> findSupplementsWithIngredientsByIds(@Param("ids") List<Long> ids);
+
+    @EntityGraph(attributePaths = {"brand", "supplementIngredients", "supplementIngredients.ingredient"})
+    Optional<Supplement> findByIdWithIngredientsAndBrand(Long id);
 }


### PR DESCRIPTION
Close #125 

## 📝 작업 내용
특정 영양제의 상세 정보를 반환하는 API를 만들었습니다.
영양제 id를 query parameter로 받아 상세정보를 조회하여 Figma 상세화면과 같은 형태로 제공합니다
(영양제 상세성분, 특정 브랜드의 모든 영양제는 별도 API로 분리하였기 때문에 이 API에는 데이터가 없습니다)

## ✅ 변경 사항
- [ ] Brand 도메인에 imageUrl 필드 수정
- [ ] SupplementService 내부 메소드 추가
- [ ] 각종 Repository 메소드 추가 및 responseDTO, controller 추가 
