### PR TITLE
fix(#131): findByIdWithIngredientsAndBrands를 findById로 수정

### DIFF
--- a/src/main/java/com/vitacheck/repository/SupplementRepository.java
+++ b/src/main/java/com/vitacheck/repository/SupplementRepository.java
@@ -14,5 +14,5 @@ public interface SupplementRepository extends JpaRepository<Supplement, Long>, S
     List<Supplement> findSupplementsWithIngredientsByIds(@Param("ids") List<Long> ids);
 
     @EntityGraph(attributePaths = {"brand", "supplementIngredients", "supplementIngredients.ingredient"})
-    Optional<Supplement> findByIdWithIngredientsAndBrand(Long id);
+    Optional<Supplement> findById(Long id);
 }

--- a/src/main/java/com/vitacheck/service/SupplementService.java
+++ b/src/main/java/com/vitacheck/service/SupplementService.java
@@ -125,7 +125,7 @@ public class SupplementService {
 
     @Transactional(readOnly = true)
     public SupplementDetailResponseDto getSupplementDetail(Long supplementId, Long userId) {
-        Supplement supplement = supplementRepository.findByIdWithIngredientsAndBrand(supplementId)
+        Supplement supplement = supplementRepository.findById(supplementId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 영양제를 찾을 수 없습니다."));
 
         boolean liked = likeRepository.existsByUserIdAndSupplementId(userId, supplementId);


### PR DESCRIPTION
Close #131 

## 📝 작업 내용
Spring Data JPA의 Query Creation 규칙과 충돌하여 애플리케이션 실행 시 발생하던 QueryCreationException 버그를 수정했습니다.

## ✅ 변경 사항
SupplementRepository.java:
- @EntityGraph가 적용된 메소드 이름을 findByIdWithIngredientsAndBrand(Long id)에서 findById(Long id)로 변경했습니다.
- 이를 통해 Spring Data JPA가 메소드 이름을 잘못 해석하여 발생하는 오류를 해결했습니다.

SupplementService.java:
- SupplementRepository의 메소드명 변경에 따라, 영양제 상세 정보를 조회하는 getSupplementDetail 메소드 내의 호출을supplementRepository.findById(supplementId)로 수정했습니다.
