### PR TITLE
feat(#135): 찜한 성분 조회 API 설계 완료

### DIFF
--- a/src/main/java/com/vitacheck/dto/LikedIngredientResponseDto.java
+++ b/src/main/java/com/vitacheck/dto/LikedIngredientResponseDto.java
@@ -1,4 +1,24 @@
 package com.vitacheck.dto;
 
+import com.vitacheck.domain.Ingredient;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
 public class LikedIngredientResponseDto {
+
+    private Long ingredientId;
+    private String name;
+    private String effect;
+
+    public static LikedIngredientResponseDto from(Ingredient ingredient) {
+        return LikedIngredientResponseDto.builder()
+                .ingredientId(ingredient.getId())
+                .name(ingredient.getName())
+                .effect(ingredient.getEffect())
+                .build();
+    }
 }

--- a/src/main/java/com/vitacheck/repository/IngredientLikeRepository.java
+++ b/src/main/java/com/vitacheck/repository/IngredientLikeRepository.java
@@ -5,6 +5,7 @@ import com.vitacheck.domain.IngredientLike;
 import com.vitacheck.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface IngredientLikeRepository extends JpaRepository<IngredientLike, Long> {
@@ -14,4 +15,6 @@ public interface IngredientLikeRepository extends JpaRepository<IngredientLike, 
     boolean existsByUserAndIngredient(User user, Ingredient ingredient);
 
     void deleteByUserAndIngredient(User user, Ingredient ingredient);
+
+    List<IngredientLike> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/vitacheck/service/IngredientLikeQueryService.java
+++ b/src/main/java/com/vitacheck/service/IngredientLikeQueryService.java
@@ -1,4 +1,26 @@
 package com.vitacheck.service;
 
+import com.vitacheck.domain.IngredientLike;
+import com.vitacheck.domain.user.User;
+import com.vitacheck.dto.LikedIngredientResponseDto;
+import com.vitacheck.repository.IngredientLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class IngredientLikeQueryService {
+
+    private final IngredientLikeRepository ingredientLikeRepository;
+
+    public List<LikedIngredientResponseDto> getLikedIngredientsByUserId(Long userId) {
+        List<IngredientLike> likes = ingredientLikeRepository.findAllByUserId(userId);
+        return likes.stream()
+                .map(like -> LikedIngredientResponseDto.from(like.getIngredient()))
+                .toList();
+    }
 }


### PR DESCRIPTION
Close #135 

## ## 📝 작업 내용
GET /api/v1/users/me/likes/ingredients API 구현
IngredientLikeQueryService 생성 및 비즈니스 로직 구현
IngredientLikeRepository에 findAllByUserId(Long userId) 메서드 추가
응답 DTO: LikedIngredientResponseDto 생성 (ingredientId, name 포함)
인증 실패 시 401 응답 처리 (userDetails == null 체크)

## ## ✅ 변경 사항
LikeController에 성분 찜 목록 조회 API 메서드 추가
Swagger 문서화 (@Operation, @ApiResponse 등 적용)
인증 미들웨어 통과하지 못하면 UNAUTHORIZED 응답 처리 추가

## ## 💬 리뷰어에게
리뷰부탁드립니다!