### PR TITLE
Feature/#145 delete notification routine

### DIFF
--- a/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
@@ -69,4 +69,23 @@ public class NotificationRoutineController {
         List<RoutineResponseDto> response = routineQueryService.getMyRoutines(userId);
         return ResponseEntity.ok(CustomResponse.ok(response));
     }
+
+    @DeleteMapping("/routines/{id}")
+    @Operation(summary = "복용 루틴 삭제", description = "현재 로그인한 사용자의 특정 복용 루틴을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "복용 루틴 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "삭제 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "루틴을 찾을 수 없음")
+    })
+    public ResponseEntity<CustomResponse<Void>> deleteRoutine(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable("id") Long routineId
+    ) {
+        String email = userDetails.getUsername();
+        Long userId = userService.findIdByEmail(email);
+
+        notificationRoutineCommandService.deleteRoutine(userId, routineId);
+        return ResponseEntity.ok(CustomResponse.ok(null));
+    }
 }

--- a/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
@@ -70,7 +70,7 @@ public class NotificationRoutineController {
         return ResponseEntity.ok(CustomResponse.ok(response));
     }
 
-    @DeleteMapping("/routines/{id}")
+    @DeleteMapping("/routines/{notificationRoutineId}")
     @Operation(summary = "복용 루틴 삭제", description = "현재 로그인한 사용자의 특정 복용 루틴을 삭제합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "복용 루틴 삭제 성공"),
@@ -80,7 +80,7 @@ public class NotificationRoutineController {
     })
     public ResponseEntity<CustomResponse<Void>> deleteRoutine(
             @AuthenticationPrincipal UserDetails userDetails,
-            @PathVariable("id") Long routineId
+            @PathVariable("notificationRoutineId") Long routineId
     ) {
         String email = userDetails.getUsername();
         Long userId = userService.findIdByEmail(email);

--- a/src/main/java/com/vitacheck/domain/notification/NotificationRoutine.java
+++ b/src/main/java/com/vitacheck/domain/notification/NotificationRoutine.java
@@ -1,5 +1,6 @@
 package com.vitacheck.domain.notification;
 
+import com.vitacheck.domain.IntakeRecord;
 import com.vitacheck.domain.common.BaseTimeEntity;
 import com.vitacheck.domain.RoutineDay;
 import com.vitacheck.domain.RoutineTime;
@@ -40,6 +41,9 @@ public class NotificationRoutine extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "notificationRoutine", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RoutineTime> routineTimes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "notificationRoutine", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<IntakeRecord> intakeRecords = new ArrayList<>();
 
     @Builder
     public NotificationRoutine(User user, Supplement supplement) {

--- a/src/main/java/com/vitacheck/service/NotificationRoutineCommandService.java
+++ b/src/main/java/com/vitacheck/service/NotificationRoutineCommandService.java
@@ -85,4 +85,16 @@ public class NotificationRoutineCommandService {
                         .toList())
                 .build();
     }
+
+    public void deleteRoutine(Long userId, Long routineId) {
+        NotificationRoutine routine = notificationRoutineRepository.findById(routineId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROUTINE_NOT_FOUND));
+
+        // 본인 루틴이 아닌 경우
+        if (!routine.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.ROUTINE_NOT_FOUND);
+        }
+
+        notificationRoutineRepository.delete(routine);
+    }
 }


### PR DESCRIPTION
Close #145 

## ## 📝 작업 내용
- 복용 루틴 삭제 API 구현 (`DELETE /api/v1/notifications/routines/{id}`)
- 루틴 삭제 시 연관된 섭취 여부(`intake_records`)도 함께 삭제되도록 연관관계 설정

## ## ✅ 변경 사항
- `NotificationRoutineController`에 삭제 엔드포인트 추가
- `NotificationRoutineCommandService`에 삭제 로직 구현 (`deleteRoutine`)
- `NotificationRoutine` 엔티티에 `intakeRecords` 연관 필드 추가
  - `cascade = CascadeType.REMOVE`, `orphanRemoval = true`
- Swagger 문서화 (@Operation, @ApiResponses 등)

## ## 💬 리뷰어에게
리뷰 부탁드립니다 !