### PR TITLE
feat(#147): 복용루틴 등록 수정 통합 API 완료

### DIFF
--- a/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
@@ -33,14 +33,21 @@ public class NotificationRoutineController {
     private final UserService userService;
 
     @PostMapping("/routines")
-    @Operation(summary = "복용 루틴 등록", description = "현재 로그인한 사용자의 영양제 복용 루틴을 등록합니다.")
+    @Operation(
+        summary = "복용 루틴 등록/수정",
+        description = """
+        현재 로그인한 사용자의 복용 루틴을 등록하거나 수정합니다.  
+        - `notificationRoutineId`가 **없으면 등록**,  
+        - `notificationRoutineId`가 **있으면 해당 루틴을 수정**합니다.
+        """
+    )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "복용 루틴 등록 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "201", description = "복용 루틴 등록 또는 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (중복 루틴, 필드 오류 등)"),
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-            @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음")
+            @ApiResponse(responseCode = "404", description = "사용자 또는 루틴을 찾을 수 없음")
     })
-    public ResponseEntity<CustomResponse<RoutineRegisterResponseDto>> registerRoutine(
+    public ResponseEntity<CustomResponse<RoutineRegisterResponseDto>> registerOrUpdateRoutine(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestBody @Valid RoutineRegisterRequestDto request
     ) {

--- a/src/main/java/com/vitacheck/dto/RoutineRegisterRequestDto.java
+++ b/src/main/java/com/vitacheck/dto/RoutineRegisterRequestDto.java
@@ -15,6 +15,9 @@ import java.util.List;
 @AllArgsConstructor
 public class RoutineRegisterRequestDto {
 
+    @Schema(description = "루틴 ID (수정 시에만 전달)", example = "5")
+    private Long notificationRoutineId;
+
     @Schema(description = "복용할 영양제 ID", example = "1")
     private Long supplementId;
 


### PR DESCRIPTION
Close #147 

## ## 📝 작업 내용
- 복용 루틴 등록/수정 기능을 하나의 API로 통합
- `notificationRoutineId`가 없으면 등록, 있으면 수정으로 분기 처리

## ## ✅ 변경 사항
- RoutineRegisterRequestDto: `notificationRoutineId` 필드 추가
- NotificationRoutineCommandService:
- 등록/수정 로직 분기 통합
- 기존 루틴의 요일/시간 clear 후 재설정
- Controller: Swagger 주석 수정 (등록/수정 설명 추가)

## ## 💬 리뷰어에게
리뷰 부탁드립니다 !