### PR TITLE
[FEAT] 특정 브랜드의 다른 영양제 목록 반환 API 제작

### DIFF
--- a/src/main/java/com/vitacheck/controller/SupplementController.java
+++ b/src/main/java/com/vitacheck/controller/SupplementController.java
@@ -20,6 +20,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -83,4 +84,12 @@ public class SupplementController {
                                                      @RequestHeader(name = "X-User-Id") Long userId) {
         return supplementService.getSupplementDetail(id, userId);
     }
+
+    // 특정 브랜드 다른 영양제 목록 반환 API
+    @GetMapping("/brand")
+    public Map<String, List<SupplementDto.SimpleResponse>> getByBrandId(@RequestParam Long id) {
+        List<SupplementDto.SimpleResponse> list = supplementService.getSupplementsByBrandId(id);
+        return Map.of("supplements", list);
+    }
+
 }

--- a/src/main/java/com/vitacheck/dto/SupplementDto.java
+++ b/src/main/java/com/vitacheck/dto/SupplementDto.java
@@ -62,4 +62,21 @@ public class SupplementDto {
                     .build();
         }
     }
+
+    // 특정 브랜드의 다른 영양제 목록 반환 시 사용할 간단한 DTO입니당 by 나영
+    @Getter
+    @Builder
+    public static class SimpleResponse {
+        private Long id;
+        private String name;
+        private String imageUrl;
+
+        public static SimpleResponse from(Supplement supplement) {
+            return SimpleResponse.builder()
+                    .id(supplement.getId())
+                    .name(supplement.getName())
+                    .imageUrl(supplement.getImageUrl())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/vitacheck/repository/SupplementRepository.java
+++ b/src/main/java/com/vitacheck/repository/SupplementRepository.java
@@ -15,4 +15,6 @@ public interface SupplementRepository extends JpaRepository<Supplement, Long>, S
 
     @EntityGraph(attributePaths = {"brand", "supplementIngredients", "supplementIngredients.ingredient"})
     Optional<Supplement> findById(Long id);
+
+    List<Supplement> findAllByBrandId(Long brandId);
 }

--- a/src/main/java/com/vitacheck/service/SupplementService.java
+++ b/src/main/java/com/vitacheck/service/SupplementService.java
@@ -149,4 +149,10 @@ public class SupplementService {
                 .build();
     }
 
+    public List<SupplementDto.SimpleResponse> getSupplementsByBrandId(Long brandId) {
+        return supplementRepository.findAllByBrandId(brandId).stream()
+                .map(SupplementDto.SimpleResponse::from)
+                .toList();
+    }
+
 }


### PR DESCRIPTION
Close #151 

## 📝 작업 내용
사용자가 어떤 영양제를 볼 때, 하단에 이 영양제를 만든 브랜드의 다른 영영제 목록을 출력하는 컴포넌트 내부 데이터를 반환해주는 API 입니다 

## ✅ 변경 사항
- [ ] SupplementService 내부 로직 추가 
- [ ] SupplementRepository 내부 로직 추가 
- [ ] SupplementDto 내부 DTO 추가
- [ ] SupplementController 내부 Controller 추가 
