### PR TITLE
[REFRACTOR] 성분 관련 api 데이터 한번에 넘기는 걸로 수정 + (feat#77)관련 영양제 조회 기능 추가

### DIFF
--- a/src/main/java/com/vitacheck/config/jwt/CustomUserDetails.java
+++ b/src/main/java/com/vitacheck/config/jwt/CustomUserDetails.java
@@ -35,6 +35,9 @@ public class CustomUserDetails implements UserDetails {
         // Principal을 식별할 수 있는 고유한 값으로, 여기서는 이메일을 사용합니다.
         return user.getEmail();
     }
+    public User getUser() {
+        return this.user;
+    }
 
     // 아래 4개는 계정의 상태를 나타냅니다. (만료, 잠김 등)
     @Override

--- a/src/main/java/com/vitacheck/controller/IngredientController.java
+++ b/src/main/java/com/vitacheck/controller/IngredientController.java
@@ -3,6 +3,7 @@ package com.vitacheck.controller;
 import com.vitacheck.domain.Ingredient;
 import com.vitacheck.dto.IngredientResponseDTO;
 import com.vitacheck.global.apiPayload.CustomResponse;
+import com.vitacheck.repository.IngredientRepository;
 import com.vitacheck.service.IngredientService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -10,16 +11,36 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 
 @RestController
 @RequiredArgsConstructor
 public class IngredientController {
     private final IngredientService ingredientService;
+    private final IngredientRepository ingredientRepository;
+
+
+    @Operation(
+            summary = "성분 검색 조회 API By 박지영",
+            description = """
+        성분의 이름으로 검색 결과를 반환합니다...
+        해당 성분을 사용자가 누르면, 성분 id로 성분 상세 조회를 요청해주세요
+        """
+
+    )
+    @GetMapping("/api/v1/ingredients/search")
+    public CustomResponse<List<IngredientResponseDTO.IngredientName>> getIngredientFood(
+            @Parameter(name = "keyword", description = "검색 키워드", example = "유산균")
+            @RequestParam String keyword) {
+        List<IngredientResponseDTO.IngredientName> responseDto = ingredientService.searchIngredientName(keyword);
+        return CustomResponse.ok(responseDto);
+    }
 
     @Operation(
             summary = "성분 상세 조회 API By 박지영",
             description = """
-        성분의 설명, 효능, 부작용 및 주의사항, 상한 섭취량, 하한 섭취량 등을 반환합니다..
+        성분의 설명, 효능, 부작용 및 주의사항, 상한 섭취량, 하한 섭취량, 대체식품 등을 반환합니다..
         """
 
     )
@@ -31,19 +52,6 @@ public class IngredientController {
         return CustomResponse.ok(responseDto);
     }
 
-    @Operation(
-            summary = "성분 대체 식품 조회 API By 박지영",
-            description = """
-        성분의 대체식품을 반환합니다..
-        """
 
-    )
-    @GetMapping("/api/v1/ingredients/{id}/foods")
-    public CustomResponse<IngredientResponseDTO.IngredientFood> getIngredientFood(
-            @Parameter(name = "id", description = "성분 ID", example = "1")
-            @PathVariable Long id) {
-        IngredientResponseDTO.IngredientFood responseDto = ingredientService.getAlternativeFoods(id);
-        return CustomResponse.ok(responseDto);
-    }
 
 }

--- a/src/main/java/com/vitacheck/dto/IngredientResponseDTO.java
+++ b/src/main/java/com/vitacheck/dto/IngredientResponseDTO.java
@@ -26,6 +26,10 @@ public class IngredientResponseDTO {
         private Double recommendedDosage;     // 하한
         private String unit;           // 단위
         private List<SubIngredient> subIngredients = new ArrayList<>(); // 대체 식품
+        private List<IngredientSupplement> supplements; // 영양제
+        private String DosageErrorCode;  // 상한, 권장량 오류
+        private String FoodErrorCode;    // 대체 식품 오류
+        private String SupplementErrorCode;  // 관련 영양제 오류
     }
 
     @Getter
@@ -35,8 +39,7 @@ public class IngredientResponseDTO {
     public static class IngredientSupplement{
         private Long id;
         private String name;
-        @Builder.Default
-        private List<SubIngredient> subIngredients = new ArrayList<>();
+        private String ImageUrl;
     }
 
 //    @Getter

--- a/src/main/java/com/vitacheck/dto/IngredientResponseDTO.java
+++ b/src/main/java/com/vitacheck/dto/IngredientResponseDTO.java
@@ -25,6 +25,7 @@ public class IngredientResponseDTO {
         private Double upperLimit;     // 상한
         private Double recommendedDosage;     // 하한
         private String unit;           // 단위
+        private List<SubIngredient> subIngredients = new ArrayList<>(); // 대체 식품
     }
 
     @Getter
@@ -38,16 +39,16 @@ public class IngredientResponseDTO {
         private List<SubIngredient> subIngredients = new ArrayList<>();
     }
 
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Builder
-    public static class IngredientFood{
-        private Long id;
-        private String name;
-        @Builder.Default
-        private List<SubIngredient> subIngredients = new ArrayList<>();
-    }
+//    @Getter
+//    @AllArgsConstructor
+//    @NoArgsConstructor
+//    @Builder
+//    public static class IngredientFood{
+//        private Long id;
+//        private String name;
+//        @Builder.Default
+//        private List<SubIngredient> subIngredients = new ArrayList<>();
+//    }
 
     @Getter
     @AllArgsConstructor
@@ -56,6 +57,15 @@ public class IngredientResponseDTO {
     public static class SubIngredient {
         private String name;
         private String imageOrEmoji;  // 이미지 URL 또는 이모지 표현
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class IngredientName {
+        private Long id;
+        private String name;
     }
 
 

--- a/src/main/java/com/vitacheck/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/vitacheck/global/apiPayload/code/ErrorCode.java
@@ -40,8 +40,9 @@ public enum ErrorCode implements BaseErrorCode {
     // 성분 관련
     INGREDIENT_NOT_FOUND("INGREDIENT404_0","해당 성분이 존재하지 않습니다.",HttpStatus.NOT_FOUND),
     INGREDIENT_FOOD_NOT_FOUND("INGREDIENT404_1","대체 식품이 존재하지 않습니다.",HttpStatus.NOT_FOUND),
-    INGREDIENT_DOSAGE_NOT_FOUND("INGREDIENT404_2","상한 및 하한이 존재하지 않습니다.",HttpStatus.NOT_FOUND),
-    INGREDIENT_USER_DOSAGE_NOT_FOUND("INGREDIENT404_2","사용자 연령과 성별에 맞는 상한 및 하한이 존재하지 않습니다.",HttpStatus.NOT_FOUND);
+    INGREDIENT_DOSAGE_NOT_FOUND("INGREDIENT404_2","상한 및 하한 값이 존재하지 않습니다.",HttpStatus.NOT_FOUND),
+    INGREDIENT_DOSAGE_HAVE_NULL("INGREDIENT404_3","상한과 하한 중 하나의 값이 존재하지 않습니다.",HttpStatus.NOT_FOUND),
+    INGREDIENT_SUPPLEMENT_NOT_FOUND("INGREDIENT404_4","성분과 관련된 영양제가 존재하지 않습니다.",HttpStatus.NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/vitacheck/service/IngredientService.java
+++ b/src/main/java/com/vitacheck/service/IngredientService.java
@@ -1,10 +1,9 @@
 package com.vitacheck.service;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.vitacheck.domain.AlternativeFood;
-import com.vitacheck.domain.Ingredient;
-import com.vitacheck.domain.IngredientDosage;
-import com.vitacheck.domain.QAlternativeFood;
+import com.vitacheck.config.jwt.CustomUserDetails;
+import com.vitacheck.domain.*;
 import com.vitacheck.domain.mapping.QIngredientAlternativeFood;
 import com.vitacheck.domain.mapping.QSupplementIngredient;
 import com.vitacheck.domain.user.Gender;
@@ -23,6 +22,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -52,35 +52,64 @@ public class IngredientService {
     }
 
     public IngredientResponseDTO.IngredientDetails getIngredientDetails(Long id) {
+        String dosageErrorCode = null;
+        String foodErrorCode = null;
+        String supplementErrorCode = null;
+
+
         // 1. 성분 가져오기
         Ingredient ingredient = ingredientRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.INGREDIENT_NOT_FOUND));
 
+        Gender gender = Gender.NONE;
+        int ageGroup = 0;
+
         // 2. 사용자 정보 가져오기 (로그인 여부에 따라 기본값 처리)
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        Gender gender;
-        int ageGroup;
 
         if (authentication == null || !authentication.isAuthenticated() || authentication.getPrincipal().equals("anonymousUser")) {
             // 로그인하지 않은 경우 기본값 설정
-            gender = Gender.ALL;
-            ageGroup = 30;
+            dosageErrorCode = ErrorCode.UNAUTHORIZED.name();
 
         } else {
-            User user = (User) authentication.getPrincipal();
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            User user = userDetails.getUser();
             gender = user.getGender();
 
             LocalDate birthDate = user.getBirthDate();
             int age = Period.between(birthDate, LocalDate.now()).getYears();
             ageGroup = (age / 10) * 10;
-
+            System.out.println(age);
+            System.out.println(gender);
 
         }
-        IngredientDosage dosage = ingredientDosageRepository.findBestDosage(id,gender,ageGroup)
-                .orElseThrow(() -> new CustomException(ErrorCode.INGREDIENT_USER_DOSAGE_NOT_FOUND));
 
+        // 3. 섭취 기준 (dosage) 조회
+        // 기본값 세팅 (-1이면 값 없다는 뜻)
+        Double recommendedDosage = -1.0;
+        Double upperLimit = -1.0;
 
+        if (dosageErrorCode == null) {
+            IngredientDosage dosage = ingredientDosageRepository.findBestDosage(id, gender, ageGroup)
+                    .orElse(null);
+
+            if (dosage == null) {
+                dosageErrorCode = ErrorCode.INGREDIENT_DOSAGE_NOT_FOUND.name();
+            } else {
+                // 값은 있으나 필드가 null일 수 있는 경우 처리
+                if (dosage.getRecommendedDosage() == null || dosage.getUpperLimit() == null) {
+                    dosageErrorCode = ErrorCode.INGREDIENT_DOSAGE_HAVE_NULL.name();
+                } else {
+                    recommendedDosage = dosage.getRecommendedDosage();
+                    upperLimit = dosage.getUpperLimit();
+                }
+            }
+        }
+
+//        IngredientDosage dosage = ingredientDosageRepository.findBestDosage(id,gender,ageGroup)
+//                .orElseThrow(() -> new CustomException(ErrorCode.INGREDIENT_USER_DOSAGE_NOT_FOUND));
+//
         // 4. 중간 테이블에서 대체 식품 ID 조회
         QIngredientAlternativeFood iaf = QIngredientAlternativeFood.ingredientAlternativeFood;
         List<Long> foodIds = queryFactory
@@ -90,82 +119,68 @@ public class IngredientService {
                 .fetch();
 
         // 5. 대체 식품 상세 정보 조회
-        if (foodIds.isEmpty()) {
-            throw new CustomException(ErrorCode.INGREDIENT_FOOD_NOT_FOUND);
-        }
+        List<IngredientResponseDTO.SubIngredient> foodDTOs = new ArrayList<>();
 
-        // 6. 대체 식품 조회
-        QAlternativeFood af=QAlternativeFood.alternativeFood;
-        List<AlternativeFood> alternativeFoods = queryFactory
-                .selectFrom(af)
-                .where(af.id.in(foodIds))
-                .fetch();
+        if (!foodIds.isEmpty()) {
+                QAlternativeFood af = QAlternativeFood.alternativeFood;
+                List<AlternativeFood> alternativeFoods = queryFactory
+                        .selectFrom(af)
+                        .where(af.id.in(foodIds))
+                        .fetch();
 
-        List<IngredientResponseDTO.SubIngredient> foodDTOs=alternativeFoods.stream()
-                .map(f -> IngredientResponseDTO.SubIngredient.builder()
-                        .name(f.getName())
-                        .imageOrEmoji(f.getEmoji())
-                        .build())
-                .toList();
-
-//        // 7. 관련 영양제 조회
-//        QSupplementIngredient si=QSupplementIngredient.supplementIngredient;
-//        List<>
-
-        return IngredientResponseDTO.IngredientDetails.builder()
-                .id(ingredient.getId())
-                .name(ingredient.getName())
-                .description(ingredient.getDescription())
-                .effect(ingredient.getEffect())
-                .caution(ingredient.getCaution())
-                .age(ageGroup)
-                .gender(dosage.getGender())
-                .recommendedDosage(dosage.getRecommendedDosage())
-                .upperLimit(dosage.getUpperLimit())
-                .unit(ingredient.getUnit())
-                .subIngredients(foodDTOs)
-                .build();
-
-    }
-
-//    public IngredientResponseDTO.IngredientFood getAlternativeFoods(Long id) {
-//        // 1. 성분 ID 조회
-//        Ingredient ingredient = ingredientRepository.findById(id)
-//                .orElseThrow(() -> new CustomException(ErrorCode.INGREDIENT_NOT_FOUND));
-
-//        // 2. 중간 테이블에서 대체 식품 ID 조회
-//        QIngredientAlternativeFood iaf = QIngredientAlternativeFood.ingredientAlternativeFood;
-//        List<Long> foodIds = queryFactory
-//                .select(iaf.alternativeFood.id)
-//                .from(iaf)
-//                .where(iaf.ingredient.id.eq(id))
-//                .fetch();
-//
-//        // 3. 대체 식품 상세 정보 조회
+                foodDTOs = alternativeFoods.stream()
+                        .map(f -> IngredientResponseDTO.SubIngredient.builder()
+                                .name(f.getName())
+                                .imageOrEmoji(f.getEmoji())
+                                .build())
+                        .toList();
+            } else {
+                foodErrorCode = ErrorCode.INGREDIENT_FOOD_NOT_FOUND.name();
+            }
 //        if (foodIds.isEmpty()) {
 //            throw new CustomException(ErrorCode.INGREDIENT_FOOD_NOT_FOUND);
 //        }
-//
-//        // 4. 대체 식품 조회
-//        QAlternativeFood af=QAlternativeFood.alternativeFood;
-//        List<AlternativeFood> alternativeFoods = queryFactory
-//                .selectFrom(af)
-//                .where(af.id.in(foodIds))
-//                .fetch();
-//
-//
-//        List<IngredientResponseDTO.SubIngredient> foodDTOs=alternativeFoods.stream()
-//                .map(f -> IngredientResponseDTO.SubIngredient.builder()
-//                        .name(f.getName())
-//                        .imageOrEmoji(f.getEmoji())
-//                        .build())
-//                .toList();
-//
-//        return IngredientResponseDTO.IngredientFood.builder()
-//                .id(ingredient.getId())
-//                .name(ingredient.getName())
-//                .subIngredients(foodDTOs)
-//                .build();
-//    }
 
-}
+            // 7. 관련 영양제 조회
+            QSupplementIngredient si = QSupplementIngredient.supplementIngredient;
+            QSupplement s = QSupplement.supplement;
+
+            List<IngredientResponseDTO.IngredientSupplement> supplements = queryFactory
+                    .select(Projections.fields(
+                            IngredientResponseDTO.IngredientSupplement.class,
+                            s.id.as("id"),
+                            s.name.as("name"),
+                            s.imageUrl.as("imageUrl")
+                    ))
+                    .from(si)
+                    .join(s).on(si.supplement.id.eq(s.id))
+                    .where(si.ingredient.id.eq(id))
+                    .fetch();
+
+            supplementErrorCode = supplements.isEmpty()
+                    ? ErrorCode.INGREDIENT_SUPPLEMENT_NOT_FOUND.name()
+                    : null;
+
+            return IngredientResponseDTO.IngredientDetails.builder()
+                    .id(ingredient.getId())
+                    .name(ingredient.getName())
+                    .description(ingredient.getDescription())
+                    .effect(ingredient.getEffect())
+                    .caution(ingredient.getCaution())
+                    .age(ageGroup)
+                    .gender(gender)
+//                .recommendedDosage(dosage.getRecommendedDosage())
+//                .upperLimit(dosage.getUpperLimit())
+                    .recommendedDosage(recommendedDosage)
+                    .upperLimit(upperLimit)
+                    .unit(ingredient.getUnit())
+                    .subIngredients(foodDTOs)
+                    .supplements(supplements)
+                    .DosageErrorCode(dosageErrorCode)
+                    .FoodErrorCode(foodErrorCode)
+                    .SupplementErrorCode(supplementErrorCode)
+                    .build();
+
+        }
+
+    }

--- a/src/main/java/com/vitacheck/service/IngredientService.java
+++ b/src/main/java/com/vitacheck/service/IngredientService.java
@@ -6,6 +6,7 @@ import com.vitacheck.domain.Ingredient;
 import com.vitacheck.domain.IngredientDosage;
 import com.vitacheck.domain.QAlternativeFood;
 import com.vitacheck.domain.mapping.QIngredientAlternativeFood;
+import com.vitacheck.domain.mapping.QSupplementIngredient;
 import com.vitacheck.domain.user.Gender;
 import com.vitacheck.domain.user.User;
 import com.vitacheck.dto.IngredientResponseDTO;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.Period;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,17 +35,27 @@ public class IngredientService {
     private final JPAQueryFactory queryFactory;
     private final IngredientDosageRepository ingredientDosageRepository;
 
+    public List<IngredientResponseDTO.IngredientName> searchIngredientName(String keyword) {
+        //1. 성분 이름으로 검색
+        List<Ingredient> ingredients=ingredientRepository.findByNameContainingIgnoreCase(keyword);
+
+        if (ingredients.isEmpty()) {
+            throw new CustomException(ErrorCode.INGREDIENT_NOT_FOUND);
+        }
+
+        return ingredients.stream()
+                .map(ingredient -> IngredientResponseDTO.IngredientName.builder()
+                        .id(ingredient.getId())
+                        .name(ingredient.getName())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
     public IngredientResponseDTO.IngredientDetails getIngredientDetails(Long id) {
         // 1. 성분 가져오기
         Ingredient ingredient = ingredientRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.INGREDIENT_NOT_FOUND));
 
-//        // 2. 현재 로그인한 사용자 정보 가져오기
-//        User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-//        Gender gender = user.getGender();
-//        LocalDate birthDate = user.getBirthDate();
-//        int age = Period.between(birthDate, LocalDate.now()).getYears();  // 나이 계산
-//        int ageGroup = (age / 10) * 10;
         // 2. 사용자 정보 가져오기 (로그인 여부에 따라 기본값 처리)
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
@@ -54,6 +66,7 @@ public class IngredientService {
             // 로그인하지 않은 경우 기본값 설정
             gender = Gender.ALL;
             ageGroup = 30;
+
         } else {
             User user = (User) authentication.getPrincipal();
             gender = user.getGender();
@@ -61,12 +74,43 @@ public class IngredientService {
             LocalDate birthDate = user.getBirthDate();
             int age = Period.between(birthDate, LocalDate.now()).getYears();
             ageGroup = (age / 10) * 10;
+
+
+        }
+        IngredientDosage dosage = ingredientDosageRepository.findBestDosage(id,gender,ageGroup)
+                .orElseThrow(() -> new CustomException(ErrorCode.INGREDIENT_USER_DOSAGE_NOT_FOUND));
+
+
+        // 4. 중간 테이블에서 대체 식품 ID 조회
+        QIngredientAlternativeFood iaf = QIngredientAlternativeFood.ingredientAlternativeFood;
+        List<Long> foodIds = queryFactory
+                .select(iaf.alternativeFood.id)
+                .from(iaf)
+                .where(iaf.ingredient.id.eq(id))
+                .fetch();
+
+        // 5. 대체 식품 상세 정보 조회
+        if (foodIds.isEmpty()) {
+            throw new CustomException(ErrorCode.INGREDIENT_FOOD_NOT_FOUND);
         }
 
-        // 3. 섭취 기준 조회
-        IngredientDosage dosage = ingredientDosageRepository
-                .findBestDosage(id, gender, ageGroup)
-                .orElseThrow(() -> new CustomException(ErrorCode.INGREDIENT_USER_DOSAGE_NOT_FOUND));
+        // 6. 대체 식품 조회
+        QAlternativeFood af=QAlternativeFood.alternativeFood;
+        List<AlternativeFood> alternativeFoods = queryFactory
+                .selectFrom(af)
+                .where(af.id.in(foodIds))
+                .fetch();
+
+        List<IngredientResponseDTO.SubIngredient> foodDTOs=alternativeFoods.stream()
+                .map(f -> IngredientResponseDTO.SubIngredient.builder()
+                        .name(f.getName())
+                        .imageOrEmoji(f.getEmoji())
+                        .build())
+                .toList();
+
+//        // 7. 관련 영양제 조회
+//        QSupplementIngredient si=QSupplementIngredient.supplementIngredient;
+//        List<>
 
         return IngredientResponseDTO.IngredientDetails.builder()
                 .id(ingredient.getId())
@@ -79,48 +123,49 @@ public class IngredientService {
                 .recommendedDosage(dosage.getRecommendedDosage())
                 .upperLimit(dosage.getUpperLimit())
                 .unit(ingredient.getUnit())
-                .build();
-
-    }
-
-    public IngredientResponseDTO.IngredientFood getAlternativeFoods(Long id) {
-        // 1. 성분 ID 조회
-        Ingredient ingredient = ingredientRepository.findById(id)
-                .orElseThrow(() -> new CustomException(ErrorCode.INGREDIENT_NOT_FOUND));
-
-        // 2. 중간 테이블에서 대체 식품 ID 조회
-        QIngredientAlternativeFood iaf = QIngredientAlternativeFood.ingredientAlternativeFood;
-        List<Long> foodIds = queryFactory
-                .select(iaf.alternativeFood.id)
-                .from(iaf)
-                .where(iaf.ingredient.id.eq(id))
-                .fetch();
-
-        // 3. 대체 식품 상세 정보 조회
-        if (foodIds.isEmpty()) {
-            throw new CustomException(ErrorCode.INGREDIENT_FOOD_NOT_FOUND);
-        }
-
-        // 4. 대체 식품 조회
-        QAlternativeFood af=QAlternativeFood.alternativeFood;
-        List<AlternativeFood> alternativeFoods = queryFactory
-                .selectFrom(af)
-                .where(af.id.in(foodIds))
-                .fetch();
-
-
-        List<IngredientResponseDTO.SubIngredient> foodDTOs=alternativeFoods.stream()
-                .map(f -> IngredientResponseDTO.SubIngredient.builder()
-                        .name(f.getName())
-                        .imageOrEmoji(f.getEmoji())
-                        .build())
-                .toList();
-
-        return IngredientResponseDTO.IngredientFood.builder()
-                .id(ingredient.getId())
-                .name(ingredient.getName())
                 .subIngredients(foodDTOs)
                 .build();
+
     }
+
+//    public IngredientResponseDTO.IngredientFood getAlternativeFoods(Long id) {
+//        // 1. 성분 ID 조회
+//        Ingredient ingredient = ingredientRepository.findById(id)
+//                .orElseThrow(() -> new CustomException(ErrorCode.INGREDIENT_NOT_FOUND));
+
+//        // 2. 중간 테이블에서 대체 식품 ID 조회
+//        QIngredientAlternativeFood iaf = QIngredientAlternativeFood.ingredientAlternativeFood;
+//        List<Long> foodIds = queryFactory
+//                .select(iaf.alternativeFood.id)
+//                .from(iaf)
+//                .where(iaf.ingredient.id.eq(id))
+//                .fetch();
+//
+//        // 3. 대체 식품 상세 정보 조회
+//        if (foodIds.isEmpty()) {
+//            throw new CustomException(ErrorCode.INGREDIENT_FOOD_NOT_FOUND);
+//        }
+//
+//        // 4. 대체 식품 조회
+//        QAlternativeFood af=QAlternativeFood.alternativeFood;
+//        List<AlternativeFood> alternativeFoods = queryFactory
+//                .selectFrom(af)
+//                .where(af.id.in(foodIds))
+//                .fetch();
+//
+//
+//        List<IngredientResponseDTO.SubIngredient> foodDTOs=alternativeFoods.stream()
+//                .map(f -> IngredientResponseDTO.SubIngredient.builder()
+//                        .name(f.getName())
+//                        .imageOrEmoji(f.getEmoji())
+//                        .build())
+//                .toList();
+//
+//        return IngredientResponseDTO.IngredientFood.builder()
+//                .id(ingredient.getId())
+//                .name(ingredient.getName())
+//                .subIngredients(foodDTOs)
+//                .build();
+//    }
 
 }


### PR DESCRIPTION
Close #77 , #133 
related to #78 
## ## 📝 작업 내용
- 성분 관련 api 3개를 1개로 통합 ( 상세정보, 대체 식품, 관련 영영제 api)
- 성분으로 검색 기능 추가

## ## ✅ 변경 사항
- [x] Ingredient의 Service, Controller, ResponseDTO 수정
- [x] Errorcode에 성분 관련 에러 코드 수정
- [x] CustomUserDetails에서 getUser 메소드 추가


## ## 📷 스크린샷 (선택)
- 성분 관련 모든 정보를 한꺼번에 보내도록 api를 통합했습니다. 
<img width="50%" height="50%" alt="Image" src="https://github.com/user-attachments/assets/d1f7719a-bcf4-4073-997d-e1850a5a5487" />
<p align="center">

- 통합하는 과정에서 세부적인 에러처리를 위해 INGREDIENT_DOSAGE_NOT_FOUND , INGREDIENT_FOOD_NOT_FOUND ,INGREDIENT_SUPPLEMENT_NOT_FOUND , AUTHORIZED 에러를 인식하고 반환하도록 코드를 추가했습니다. 

  <img width="50%" height="50%" src="https://github.com/user-attachments/assets/af4d103d-9fcf-470c-bc4d-cc19abe21d8b" width="300"/>
  <img width="35%" height="35%" src="https://github.com/user-attachments/assets/6db1f2bc-8b62-4911-a7f8-4b6c82f7a5f6" width="300"/>
</p>




## ## 💬 리뷰어에게
에러처리를 하면 성분에 관한 모든 값을 반환하지 못해서, 에러 내용을 포함하여 응답을 반환하도록 하였습니다. 
프론트 측에서 관련하여 적절한 에러처리를 할 수 있게 관련 내용 전달하겠습니다.