### PR TITLE
bug(#156): 로직 수정 완료

### DIFF
--- a/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Tag(name = "notification-routines", description = "복용 루틴 관련 API")
@@ -68,12 +70,13 @@ public class NotificationRoutineController {
             @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음")
     })
     public ResponseEntity<CustomResponse<List<RoutineResponseDto>>> getMyRoutines(
-            @AuthenticationPrincipal UserDetails userDetails
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(name = "date", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
         String email = userDetails.getUsername();
         Long userId = userService.findIdByEmail(email);
 
-        List<RoutineResponseDto> response = routineQueryService.getMyRoutines(userId);
+        List<RoutineResponseDto> response = routineQueryService.getMyRoutines(userId, date);
         return ResponseEntity.ok(CustomResponse.ok(response));
     }
 

--- a/src/main/java/com/vitacheck/service/RoutineQueryService.java
+++ b/src/main/java/com/vitacheck/service/RoutineQueryService.java
@@ -1,5 +1,6 @@
 package com.vitacheck.service;
 
+import com.vitacheck.domain.IntakeRecord;
 import com.vitacheck.domain.notification.NotificationRoutine;
 import com.vitacheck.dto.RoutineResponseDto;
 import com.vitacheck.repository.IntakeRecordRepository;
@@ -18,14 +19,17 @@ public class RoutineQueryService {
     private final NotificationRoutineRepository notificationRoutineRepository;
     private final IntakeRecordRepository intakeRecordRepository;
 
-    public List<RoutineResponseDto> getMyRoutines(Long userId) {
+    public List<RoutineResponseDto> getMyRoutines(Long userId, LocalDate date) {
+        LocalDate targetDate = (date != null) ? date : LocalDate.now();
         List<NotificationRoutine> routines = notificationRoutineRepository.findAllByUserId(userId);
-        LocalDate today = LocalDate.now();
 
         return routines.stream()
                 .map(routine -> {
                     boolean isTaken = intakeRecordRepository
-                            .existsByNotificationRoutineIdAndUserIdAndDate(routine.getId(), userId, today);
+                            .findByUserAndNotificationRoutineAndDate(routine.getUser(), routine, targetDate)
+                            .map(IntakeRecord::getIsTaken)
+                            .orElse(false);
+
 
                     return RoutineResponseDto.builder()
                             .notificationRoutineId(routine.getId())


### PR DESCRIPTION
Close #156 

## ## 📝 작업 내용
복용 루틴 조회 API의 isTaken 판단 로직과 날짜 필터 기능 개선

## ## ✅ 변경 사항
RoutineQueryService에서 isTaken 값을 IntakeRecord.isTaken 기준으로 정확하게 판단하도록 수정
GET /api/v1/notifications/routines?date=YYYY-MM-DD 요청 시, date 파라미터 반영되도록 컨트롤러 및 서비스 수정
테스트를 통해 POST /records/{id}/toggle 후 해당 날짜 기준 isTaken 반영 여부 확인 완료

## ## 💬 리뷰어에게
버그 수정했습니다! 리뷰 부탁드려요!