### PR TITLE
feat(#158): 로직 수정 완료

### DIFF
--- a/src/main/java/com/vitacheck/controller/IntakeRecordController.java
+++ b/src/main/java/com/vitacheck/controller/IntakeRecordController.java
@@ -9,9 +9,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/v1/notifications/records")
@@ -23,14 +26,25 @@ public class IntakeRecordController {
     private final UserService userService;
 
     @Operation(
-            summary = "오늘의 섭취 여부 토글",
-            description = "사용자가 특정 복용 루틴에 대해 오늘 영양제를 섭취했는지를 토글합니다. 최초 등록 시 true, 다시 누르면 false로 변경됩니다.",
+            summary = "섭취 여부 토글",
+            description = """
+        사용자가 특정 복용 루틴에 대해 영양제를 섭취했는지를 토글합니다.  
+        - `date`를 입력하지 않으면 오늘 날짜 기준으로 처리됩니다.  
+        - `date` 형식은 `yyyy-MM-dd` (예: 2025-08-07)입니다.
+        - 첫 요청 시 `true`로 생성되며, 다시 요청하면 `false`로 변경됩니다.
+        """,
             parameters = {
                     @Parameter(
                             name = "notificationRoutineId",
                             description = "복용 루틴 ID",
                             required = true,
                             example = "1"
+                    ),
+                    @Parameter(
+                            name = "date",
+                            description = "기록을 토글할 날짜 (형식: yyyy-MM-dd). 입력하지 않으면 오늘 날짜가 기본값입니다.",
+                            required = false,
+                            example = "2025-08-07"
                     )
             },
             responses = {
@@ -39,15 +53,18 @@ public class IntakeRecordController {
                     @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
             }
     )
+
     @PostMapping("/{notificationRoutineId}/toggle")
     public CustomResponse<IntakeRecordResponseDto> toggleIntake(
             @PathVariable Long notificationRoutineId,
-            @AuthenticationPrincipal UserDetails userDetails
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(name = "date", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
     ) {
         String email = userDetails.getUsername();
         Long userId = userService.findIdByEmail(email);
 
-        IntakeRecordResponseDto response = intakeRecordCommandService.toggleIntake(notificationRoutineId, userId);
+        IntakeRecordResponseDto response = intakeRecordCommandService.toggleIntake(notificationRoutineId, userId, date);
         return CustomResponse.ok(response);
     }
 }

--- a/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
@@ -63,12 +63,33 @@ public class NotificationRoutineController {
     }
 
     @GetMapping("/routines")
-    @Operation(summary = "복용 루틴 목록 조회", description = "현재 로그인한 사용자의 복용 루틴 전체 목록을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "복용 루틴 조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-            @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음")
-    })
+    @Operation(
+            summary = "복용 루틴 목록 조회",
+            description = """
+        현재 로그인한 사용자의 복용 루틴 목록을 조회합니다.
+        
+        ✅ `date` 파라미터 관련  
+        - `date`를 입력하지 않으면 **오늘 날짜(LocalDate.now())** 기준으로 조회됩니다.  
+        - 날짜 형식은 `yyyy-MM-dd` (예: 2025-08-07)입니다.
+        
+        ✅ `isTaken` 필드 설명  
+        - 각 루틴의 `isTaken` 값은 해당 날짜에 등록된 섭취 기록의 `isTaken` 필드를 기준으로 판단됩니다.  
+        - 즉, 단순히 기록이 있는지 여부가 아닌 실제 저장된 `true` / `false` 값이 반영됩니다.
+        """,
+            parameters = {
+                    @io.swagger.v3.oas.annotations.Parameter(
+                            name = "date",
+                            description = "조회할 날짜 (형식: yyyy-MM-dd). 입력하지 않으면 오늘 날짜 기준으로 조회됩니다.",
+                            required = false,
+                            example = "2025-08-07"
+                    )
+            },
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "복용 루틴 조회 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+                    @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음")
+            }
+    )
     public ResponseEntity<CustomResponse<List<RoutineResponseDto>>> getMyRoutines(
             @AuthenticationPrincipal UserDetails userDetails,
             @RequestParam(name = "date", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date

--- a/src/main/java/com/vitacheck/service/IntakeRecordCommandService.java
+++ b/src/main/java/com/vitacheck/service/IntakeRecordCommandService.java
@@ -24,7 +24,7 @@ public class IntakeRecordCommandService {
     private final NotificationRoutineRepository notificationRoutineRepository;
 
     @Transactional
-    public IntakeRecordResponseDto toggleIntake(Long notificationRoutineId, Long userId) {
+    public IntakeRecordResponseDto toggleIntake(Long notificationRoutineId, Long userId, LocalDate date) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -32,10 +32,10 @@ public class IntakeRecordCommandService {
                 .findByIdAndUserId(notificationRoutineId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROUTINE_NOT_FOUND));
 
-        LocalDate today = LocalDate.now();
+        LocalDate targetDate = (date != null) ? date : LocalDate.now();
 
         IntakeRecord record = intakeRecordRepository
-                .findByUserAndNotificationRoutineAndDate(user, routine, today)
+                .findByUserAndNotificationRoutineAndDate(user, routine, targetDate)
                 .map(existing -> {
                     existing.updateIsTaken(!existing.getIsTaken()); // 상태 반전
                     return existing;
@@ -44,7 +44,7 @@ public class IntakeRecordCommandService {
                         IntakeRecord.builder()
                                 .user(user)
                                 .notificationRoutine(routine)
-                                .date(today)
+                                .date(targetDate)
                                 .isTaken(true) // 첫 등록은 true로 저장
                                 .build()
                 ));


### PR DESCRIPTION
Close #158 

## ## 📝 작업 내용
섭취 여부 토글 API와 복용 루틴 조회 API에 Swagger 명세 보강
날짜 파라미터(date)에 대한 설명 추가
미입력 시 오늘 날짜가 기본값임을 명시
입력 형식은 yyyy-MM-dd 예시 포함
isTaken 필드가 섭취 기록 존재 여부가 아닌 isTaken 실제 값 기준임을 명확히 설명

## ## ✅ 변경 사항
POST /notifications/records/{id}/toggle → Swagger에 date 파라미터 명세 및 예시 추가
GET /notifications/routines → 날짜 기본값, 형식, isTaken 판단 기준 등 상세 설명 추가

## ## 💬 리뷰어에게
Swagger 문서만 수정한 PR입니다.
프론트 개발자들이 date 파라미터 사용 시 헷갈리지 않도록 명확히 문서화했습니다.
기능 로직에는 영향 없습니다! 🙇🏻‍♂️