### PR TITLE
fix(#160): 알림설정 로직 변경

### DIFF
--- a/src/main/java/com/vitacheck/controller/NotificationSettingsController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationSettingsController.java
@@ -5,6 +5,9 @@ import com.vitacheck.global.apiPayload.CustomResponse;
 import com.vitacheck.service.NotificationSettingsService;
 import com.vitacheck.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -36,6 +39,25 @@ public class NotificationSettingsController {
     @Operation(summary = "내 알림 설정 변경", description = "특정 알림(종류/채널)의 수신 동의 여부를 변경(토글)합니다.")
     public CustomResponse<String> updateMyNotificationSetting(
             @AuthenticationPrincipal UserDetails userDetails,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "변경할 알림의 종류, 채널, 그리고 활성화 여부를 전달합니다.",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = NotificationSettingsDto.UpdateRequest.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "섭취 알림 끄기",
+                                            value = "{\"type\": \"INTAKE\", \"channel\": \"PUSH\", \"isEnabled\": false}",
+                                            summary = "섭취 푸시 알림 끄기 예시"
+                                    ),
+                                    @ExampleObject(
+                                            name = "이벤트 알림 켜기",
+                                            value = "{\"type\": \"EVENT\", \"channel\": \"SMS\", \"isEnabled\": true}",
+                                            summary = "이벤트 SMS 알림 켜기 예시"
+                                    )
+                            }
+                    )
+            )
             @RequestBody NotificationSettingsDto.UpdateRequest request
     ) {
         Long userId = userService.findIdByEmail(userDetails.getUsername());

--- a/src/main/java/com/vitacheck/service/UserService.java
+++ b/src/main/java/com/vitacheck/service/UserService.java
@@ -59,6 +59,8 @@ public class UserService {
             throw new CustomException(ErrorCode.PASSWORD_NOT_MATCH);
         }
 
+        notificationSettingsService.getNotificationSettings(user.getId());
+
         String accessToken = jwtUtil.createAccessToken(user.getEmail());
         String refreshToken = jwtUtil.createRefreshToken(user.getEmail());
 


### PR DESCRIPTION
Close #160 

## ## 📝 작업 내용
알림 설정 기능의 안정성을 높이고 API 문서의 명확성을 개선했습니다. 회원가입 및 로그인 시점에 기본 알림 설정을 자동으로 생성하여 데이터 누락으로 인한 오류를 방지하고, Swagger API 문서의 요청 예시를 수정하여 개발자의 혼동을 줄였습니다.

## ## ✅ 변경 사항
버그 수정: 회원가입 시 기본 알림 설정 생성
- 신규 사용자가 회원가입(signUp, socialSignUp)을 완료하는 시점에 모든 채널의 알림 수신 동의가 true로 설정된 기본값을 자동으로 생성하도록 UserService를 수정했습니다.
- 이를 통해, 알림 설정 데이터가 없어 발생하던 조회 API의 잠재적 오류를 해결하고 데이터 정합성을 보장합니다.

API 문서 개선: 알림 설정 변경 API의 Swagger 예시 수정
- NotificationSettingsController의 PUT /api/v1/notification-settings/me API의 Swagger 문서에서 잘못된 Request body 예시(nickname)가 표시되던 문제를 해결했습니다.
- @ExampleObject 어노테이션을 사용하여, 실제 API 명세에 맞는 올바른 JSON 형식({ "type": "INTAKE", "channel": "PUSH", "isEnabled": false })의 예시를 명시적으로 제공하도록 수정했습니다.

## ## 📷 스크린샷 (선택)
<img width="1403" height="552" alt="스크린샷 2025-08-08 오후 7 00 04" src="https://github.com/user-attachments/assets/deec0be2-e5a7-4f1f-9c73-a09433d5a98b" />
<img width="1399" height="699" alt="스크린샷 2025-08-08 오후 7 00 48" src="https://github.com/user-attachments/assets/e5074a51-10d0-4d7b-bca3-d8a3a116662a" />
