### PR TITLE
feat(#162): ec2 cron job 구현

### DIFF
--- a/src/main/java/com/vitacheck/controller/NotificationSettingsController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationSettingsController.java
@@ -1,7 +1,10 @@
 package com.vitacheck.controller;
 
 import com.vitacheck.dto.NotificationSettingsDto;
+import com.vitacheck.global.apiPayload.CustomException;
 import com.vitacheck.global.apiPayload.CustomResponse;
+import com.vitacheck.global.apiPayload.code.ErrorCode;
+import com.vitacheck.service.NotificationScheduler;
 import com.vitacheck.service.NotificationSettingsService;
 import com.vitacheck.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -24,6 +28,7 @@ public class NotificationSettingsController {
 
     private final NotificationSettingsService notificationSettingsService;
     private final UserService userService;
+    private final NotificationScheduler notificationScheduler;
 
     @GetMapping("/me")
     @Operation(summary = "내 알림 설정 조회", description = "현재 로그인한 사용자의 모든 알림 수신 동의 여부를 조회합니다.")
@@ -63,5 +68,19 @@ public class NotificationSettingsController {
         Long userId = userService.findIdByEmail(userDetails.getUsername());
         notificationSettingsService.updateNotificationSetting(userId, request);
         return CustomResponse.ok("알림 설정이 변경되었습니다.");
+    }
+
+    @PostMapping("/internal/trigger-notifications")
+    @Operation(summary = "내부용 알림 발송 트리거", description = "Cron Job에 의해 호출되어 알림 발송 로직을 실행합니다. (외부 노출 금지)")
+    public CustomResponse<String> triggerNotifications(HttpServletRequest request) {
+        // 보안을 위해 localhost에서 온 요청인지 확인합니다.
+        String remoteAddr = request.getRemoteAddr();
+        if (!remoteAddr.equals("127.0.0.1") && !remoteAddr.equals("0:0:0:0:0:0:0:1")) {
+            // 권한 없음 에러를 반환합니다.
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        notificationScheduler.sendRoutineNotifications();
+        return CustomResponse.ok("알림 발송 작업이 성공적으로 실행되었습니다.");
     }
 }


### PR DESCRIPTION
Close #162 

## 📝 작업 내용
알림 기능의 안정성과 확장성을 개선하고 API 문서의 명확성을 높이기 위한 전반적인 리팩토링 및 버그 수정을 진행했습니다.

## ✅ 변경 사항
 리팩토링: 알림 발송 스케줄러 방식 변경 (EC2 Cron Job 기반)
- 서버 부하를 줄이고 확장성을 확보하기 위해, NotificationScheduler의 @Scheduled 어노테이션을 제거했습니다.
- EC2 Cron Job이 호출할 수 있도록, 알림 발송을 트리거하는 내부 API 엔드포인트(POST /api/v1/notification-settings/internal/trigger-notifications)를 NotificationSettingsController에 새로 추가했습니다.
- 해당 API는 보안을 위해 서버 내부(localhost)요청만 허용하도록 구현했습니다.

## 💬 리뷰어에게
알림 기능의 핵심 로직과 인프라 연동 방식에 대한 변경이 있었습니다. 특히 새로 추가된 내부 API의 보안 로직과 기존 스케줄러 제거 부분을 중점적으로 확인해주시면 감사하겠습니다. 이 변경으로 서버의 안정성과 확장성이 크게 개선될 것으로 기대합니다. 코드 리뷰 부탁드립니다! 😊