### PR TITLE
feat(#173): 알림설정 저장 및 정보 업데이트 수정

### DIFF
--- a/src/main/java/com/vitacheck/controller/UserController.java
+++ b/src/main/java/com/vitacheck/controller/UserController.java
@@ -39,7 +39,7 @@ public class UserController {
         return CustomResponse.ok(myInfo);
     }
 
-    @Operation(summary = "내 정보 수정", description = "사용자의 닉네임을 수정합니다.")
+    @Operation(summary = "내 정보 수정", description = "사용자의 닉네임, 생년월일, 휴대폰 번호를 수정합니다.") // 설명 수정
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "수정 성공",
                     content = @Content(schema = @Schema(implementation = UserDto.InfoResponse.class))),
@@ -49,6 +49,19 @@ public class UserController {
     @PutMapping("/me")
     public CustomResponse<UserDto.InfoResponse> updateMyInfo(
             @AuthenticationPrincipal UserDetails userDetails,
+
+            // Swagger 예시를 직접 지정하는 어노테이션 추가
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "변경할 사용자 정보를 전달합니다. 변경을 원하지 않는 필드는 생략 가능합니다.",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = UserDto.UpdateRequest.class),
+                            examples = @ExampleObject(
+                                    name = "사용자 정보 수정 예시",
+                                    value = "{\"nickname\": \"새로운행복쿼카\", \"birthDate\": \"2000-02-20\", \"phoneNumber\": \"010-9876-5432\"}"
+                            )
+                    )
+            )
             @RequestBody UserDto.UpdateRequest request
     ) {
         String email = userDetails.getUsername();

--- a/src/main/java/com/vitacheck/domain/user/User.java
+++ b/src/main/java/com/vitacheck/domain/user/User.java
@@ -70,4 +70,17 @@ public class User extends BaseTimeEntity {
         this.lastLoginAt = LocalDateTime.now();
         return this;
     }
+
+    public void updateInfo(String nickname, LocalDate birthDate, String phoneNumber) {
+        // 값이 null이 아닌 경우에만 필드를 업데이트합니다.
+        if (nickname != null && !nickname.isBlank()) {
+            this.nickname = nickname;
+        }
+        if (birthDate != null) {
+            this.birthDate = birthDate;
+        }
+        if (phoneNumber != null && !phoneNumber.isBlank()) {
+            this.phoneNumber = phoneNumber;
+        }
+    }
 }

--- a/src/main/java/com/vitacheck/dto/UserDto.java
+++ b/src/main/java/com/vitacheck/dto/UserDto.java
@@ -81,6 +81,8 @@ public class UserDto {
     @NoArgsConstructor
     public static class UpdateRequest {
         private String nickname;
+        private LocalDate birthDate;
+        private String phoneNumber;
     }
 
     @Getter

--- a/src/main/java/com/vitacheck/service/NotificationSettingsService.java
+++ b/src/main/java/com/vitacheck/service/NotificationSettingsService.java
@@ -50,6 +50,8 @@ public class NotificationSettingsService {
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REQUEST)); // 존재하지 않는 설정을 변경하려는 경우
 
         setting.setIsEnabled(request.isEnabled());
+
+        notificationSettingsRepository.save(setting);
     }
 
     @Transactional

--- a/src/main/java/com/vitacheck/service/UserService.java
+++ b/src/main/java/com/vitacheck/service/UserService.java
@@ -121,7 +121,7 @@ public class UserService {
     public UserDto.InfoResponse updateMyInfo(String email, UserDto.UpdateRequest request) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        user.updateNickname(request.getNickname());
+        user.updateInfo(request.getNickname(), request.getBirthDate(), request.getPhoneNumber());
 
         int age = 0; // 기본값
         if (user.getBirthDate() != null) {


### PR DESCRIPTION
Close #173 

## 📝 작업 내용
사용자 피드백으로 접수된 두 가지 주요 사항을 해결했습니다. 알림 설정을 켰을 때 DB에 반영되지 않던 버그를 수정하고, 마이페이지 정보 수정 API의 기능을 확장하여 사용자 편의성을 개선했습니다.

## ✅ 변경 사항
1. 버그 수정: 알림 설정 변경이 DB에 반영되지 않는 문제 해결
- 문제 원인: NotificationSettingsService 클래스 전체에 @Transactional(readOnly = true)가 설정되어 있어, 데이터를 변경해야 하는 updateNotificationSetting 메소드까지 영향을 받아 변경 사항이 DB에 최종 커밋되지 않았습니다.
- 해결: updateNotificationSetting 메소드에 @Transactional 어노테이션을 개별적으로 추가하여, 해당 메소드는 정상적으로 쓰기 작업이 가능하도록 수정했습니다. 이로써 알림 설정을 켜는(true) 동작이 DB에 올바르게 반영됩니다.
---
2. 기능 확장: 마이페이지 정보 수정 기능 (생년월일, 연락처 추가)
기존에 닉네임만 수정 가능했던 마이페이지 정보 수정 API(PUT /api/v1/users/me)의 기능을 확장하여 생년월일과 휴대폰 번호도 함께 변경할 수 있도록 개선했습니다.
수정 내역:
- UserDto.UpdateRequest에 birthDate, phoneNumber 필드를 추가했습니다.
- User 엔티티에 여러 정보를 한 번에 업데이트하는 updateInfo 메소드를 추가했습니다.
- UserService가 확장된 DTO를 처리하도록 updateMyInfo 메소드의 로직을 수정했습니다.
