### PR TITLE
feat(#170): 완료

### DIFF
--- a/src/main/java/com/vitacheck/controller/NotificationRoutineCustomRestController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationRoutineCustomRestController.java
@@ -1,0 +1,45 @@
+package com.vitacheck.controller;
+
+import com.vitacheck.dto.CustomRoutineUpsertRequestDto;
+import com.vitacheck.dto.RoutineRegisterResponseDto;
+import com.vitacheck.global.apiPayload.CustomResponse;
+import com.vitacheck.service.NotificationRoutineCustomCommandService;
+import com.vitacheck.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "notification-routines", description = "복용 루틴 관련 API")
+@RestController
+@RequestMapping("/api/v1/notifications/routines/custom")
+@RequiredArgsConstructor
+public class NotificationRoutineCustomRestController {
+
+    private final NotificationRoutineCustomCommandService customService;
+    private final UserService userService;
+
+    // 생성/수정 통합
+    @Operation(summary = "커스텀 영양제 루틴 등록/수정(통합)")
+    @PostMapping
+    public ResponseEntity<CustomResponse<RoutineRegisterResponseDto>> upsert(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody CustomRoutineUpsertRequestDto req
+    ) {
+        Long userId = userService.findIdByEmail(userDetails.getUsername());
+        RoutineRegisterResponseDto res = customService.upsert(userId, req);
+
+        boolean isCreate = (req.getNotificationRoutineId() == null);
+        return isCreate
+                ? ResponseEntity.status(HttpStatus.CREATED).body(CustomResponse.created(res))
+                : ResponseEntity.ok(CustomResponse.ok(res));
+    }
+}

--- a/src/main/java/com/vitacheck/domain/CustomSupplement.java
+++ b/src/main/java/com/vitacheck/domain/CustomSupplement.java
@@ -1,0 +1,35 @@
+package com.vitacheck.domain;
+
+import com.vitacheck.domain.common.BaseTimeEntity;
+import com.vitacheck.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "custom_supplements",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id","name"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CustomSupplement extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    public void update(String name, String imageUrl) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/vitacheck/domain/notification/NotificationRoutine.java
+++ b/src/main/java/com/vitacheck/domain/notification/NotificationRoutine.java
@@ -1,5 +1,6 @@
 package com.vitacheck.domain.notification;
 
+import com.vitacheck.domain.CustomSupplement;
 import com.vitacheck.domain.IntakeRecord;
 import com.vitacheck.domain.RoutineDetail;
 import com.vitacheck.domain.common.BaseTimeEntity;
@@ -29,8 +30,12 @@ public class NotificationRoutine extends BaseTimeEntity {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "supplement_id", nullable = false)
+    @JoinColumn(name = "supplement_id")
     private Supplement supplement;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "custom_supplement_id")
+    private CustomSupplement customSupplement;
 
     @Column(name = "is_enabled", nullable = false)
     private boolean isEnabled = true;
@@ -55,6 +60,42 @@ public class NotificationRoutine extends BaseTimeEntity {
 
     public void clearRoutineDetails() {
         this.routineDetails.clear();
+    }
+
+    public boolean isOwner(Long userId) {
+        return this.user != null && this.user.getId().equals(userId);
+    }
+
+    public boolean isCustom() {
+        return this.customSupplement != null;
+    }
+
+    public void linkCustom(CustomSupplement cs) {
+        this.customSupplement = cs;
+        this.supplement = null;
+    }
+
+    public void linkCatalog(Supplement s) {
+        this.supplement = s;
+        this.customSupplement = null;
+    }
+
+    public static NotificationRoutine forCustom(User user, CustomSupplement cs) {
+        NotificationRoutine r = NotificationRoutine.builder()
+                .user(user)
+                .supplement(null)
+                .build();
+        r.customSupplement = cs;
+        return r;
+    }
+
+    public static NotificationRoutine forCatalog(User user, Supplement s) {
+        NotificationRoutine r = NotificationRoutine.builder()
+                .user(user)
+                .supplement(s)
+                .build();
+        r.customSupplement = null;
+        return r;
     }
 }
 

--- a/src/main/java/com/vitacheck/dto/CustomRoutineUpsertRequestDto.java
+++ b/src/main/java/com/vitacheck/dto/CustomRoutineUpsertRequestDto.java
@@ -1,0 +1,46 @@
+package com.vitacheck.dto;
+
+import com.vitacheck.domain.RoutineDayOfWeek;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter @NoArgsConstructor @AllArgsConstructor @Builder
+public class CustomRoutineUpsertRequestDto {
+    private Long notificationRoutineId;
+
+    @NotBlank
+    private String name;
+
+    @Pattern(regexp="^$|^https?://.*", message="imageUrl은 빈값 또는 http(s) URL 형식")
+    private String imageUrl;
+
+    @NotEmpty
+    @jakarta.validation.Valid
+    private List<Scheduled> schedules;
+
+    @Getter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class Scheduled {
+
+        @jakarta.validation.constraints.NotNull
+        private RoutineDayOfWeek dayOfWeek;
+
+        @jakarta.validation.constraints.NotNull
+        @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING, pattern = "HH:mm")
+        @io.swagger.v3.oas.annotations.media.Schema(
+                type = "string",
+                format = "time",
+                example = "08:00",
+                description = "24시간 포맷 HH:mm"
+        )
+        private java.time.LocalTime time;
+    }
+}

--- a/src/main/java/com/vitacheck/dto/RoutineResponseDto.java
+++ b/src/main/java/com/vitacheck/dto/RoutineResponseDto.java
@@ -1,5 +1,6 @@
 package com.vitacheck.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.vitacheck.domain.RoutineDayOfWeek;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,10 @@ public class RoutineResponseDto {
 
     private Long notificationRoutineId;
 
+    // 🔹 커스텀 여부 표시 (프론트 구분용)
+    private Boolean isCustom;
+
+    // 커스텀일 때는 null
     private Long supplementId;
 
     private String supplementName;
@@ -31,6 +36,9 @@ public class RoutineResponseDto {
     @Builder
     public static class ScheduleResponse {
         private RoutineDayOfWeek dayOfWeek;
+
+        // 🔹 Swagger/JSON에 "HH:mm"로 보이게
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
         private LocalTime time;
     }
 }

--- a/src/main/java/com/vitacheck/repository/CustomSupplementRepository.java
+++ b/src/main/java/com/vitacheck/repository/CustomSupplementRepository.java
@@ -1,0 +1,10 @@
+package com.vitacheck.repository;
+
+import com.vitacheck.domain.CustomSupplement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CustomSupplementRepository extends JpaRepository<CustomSupplement, Long> {
+    Optional<CustomSupplement> findByUserIdAndName(Long userId, String name);
+}

--- a/src/main/java/com/vitacheck/repository/NotificationRoutineRepository.java
+++ b/src/main/java/com/vitacheck/repository/NotificationRoutineRepository.java
@@ -15,26 +15,53 @@ import java.util.Optional;
 @Repository
 public interface NotificationRoutineRepository extends JpaRepository<NotificationRoutine, Long> {
 
-    @Query("SELECT rd FROM RoutineDetail rd " +
-            "JOIN rd.notificationRoutine nr " +
-            "WHERE nr.user.id = :userId " +
-            "AND nr.supplement.id = :supplementId")
-    List<RoutineDetail> findRoutineDetailsByUserIdAndSupplementId(@Param("userId") Long userId, @Param("supplementId") Long supplementId);
+    @Query("""
+        SELECT rd FROM RoutineDetail rd
+        JOIN rd.notificationRoutine nr
+        WHERE nr.user.id = :userId
+          AND nr.supplement.id = :supplementId
+    """)
+    List<RoutineDetail> findRoutineDetailsByUserIdAndSupplementId(@Param("userId") Long userId,
+                                                                  @Param("supplementId") Long supplementId);
 
     List<NotificationRoutine> findAllByUserId(Long userId);
 
+    // 🔹 조회용: 사용자 루틴 전부 (user + catalog/custom까지 fetch)
     @Query("""
         SELECT r FROM NotificationRoutine r
         JOIN FETCH r.user
-        JOIN FETCH r.supplement
+        LEFT JOIN FETCH r.supplement
+        LEFT JOIN FETCH r.customSupplement
+        WHERE r.user.id = :userId
+    """)
+    List<NotificationRoutine> findAllWithTargetsByUserId(@Param("userId") Long userId);
+
+    // 🔹 알림 전송 대상: 카탈로그/커스텀 모두 포함
+    @Query("""
+        SELECT r FROM NotificationRoutine r
+        JOIN FETCH r.user
+        LEFT JOIN FETCH r.supplement
+        LEFT JOIN FETCH r.customSupplement
         WHERE r.isEnabled = true
           AND r.id IN (
             SELECT rd.notificationRoutine.id FROM RoutineDetail rd
             WHERE rd.dayOfWeek = :dayOfWeek AND rd.time = :time
           )
     """)
-    List<NotificationRoutine> findRoutinesToSend(@Param("dayOfWeek") RoutineDayOfWeek dayOfWeek, @Param("time") LocalTime time);
+    List<NotificationRoutine> findRoutinesToSend(@Param("dayOfWeek") RoutineDayOfWeek dayOfWeek,
+                                                 @Param("time") LocalTime time);
 
     // 사용자와 루틴 ID 모두 일치하는 루틴만 조회
     Optional<NotificationRoutine> findByIdAndUserId(Long id, Long userId);
+
+    // (선택) 단건 수정 분기에 사용할 수 있는 fetch 메서드
+    @Query("""
+        SELECT r FROM NotificationRoutine r
+        LEFT JOIN FETCH r.customSupplement
+        LEFT JOIN FETCH r.supplement
+        WHERE r.id = :id
+    """)
+    Optional<NotificationRoutine> findByIdWithTargets(@Param("id") Long id);
+
+    boolean existsByCustomSupplementId(Long customSupplementId);
 }

--- a/src/main/java/com/vitacheck/service/NotificationRoutineCustomCommandService.java
+++ b/src/main/java/com/vitacheck/service/NotificationRoutineCustomCommandService.java
@@ -1,0 +1,109 @@
+package com.vitacheck.service;
+
+import com.vitacheck.domain.CustomSupplement;
+import com.vitacheck.domain.RoutineDetail;
+import com.vitacheck.domain.notification.NotificationRoutine;
+import com.vitacheck.domain.user.User;
+import com.vitacheck.dto.CustomRoutineUpsertRequestDto;
+import com.vitacheck.dto.RoutineRegisterResponseDto;
+import com.vitacheck.global.apiPayload.CustomException;
+import com.vitacheck.global.apiPayload.code.ErrorCode;
+import com.vitacheck.repository.CustomSupplementRepository;
+import com.vitacheck.repository.NotificationRoutineRepository;
+import com.vitacheck.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationRoutineCustomCommandService {
+
+    private final NotificationRoutineRepository routineRepo;
+    private final CustomSupplementRepository customRepo;
+    private final UserRepository userRepo;
+
+    public RoutineRegisterResponseDto upsert(Long userId, CustomRoutineUpsertRequestDto req) {
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        NotificationRoutine routine;
+
+        if (req.getNotificationRoutineId() == null) {
+            // ===== 생성 =====
+            // 동일 이름 있으면 재사용, 없으면 생성
+            CustomSupplement cs = customRepo.findByUserIdAndName(userId, req.getName())
+                    .orElseGet(() -> customRepo.save(
+                            CustomSupplement.builder()
+                                    .user(user)
+                                    .name(req.getName())
+                                    .imageUrl(blankToNull(req.getImageUrl()))
+                                    .build()
+                    ));
+            // 재사용 케이스라도 최신 값 반영
+            cs.update(req.getName(), blankToNull(req.getImageUrl()));
+
+            routine = NotificationRoutine.forCustom(user, cs);
+
+            // 스케줄 구성
+            routine.clearRoutineDetails();
+            req.getSchedules().forEach(s -> {
+                RoutineDetail d = RoutineDetail.builder()
+                        .dayOfWeek(s.getDayOfWeek())
+                        .time(s.getTime())
+                        .build();
+                routine.addRoutineDetail(d);
+            });
+
+            routineRepo.save(routine); // 생성은 save 필요
+
+        } else {
+            // ===== 수정 =====
+            routine = routineRepo.findByIdWithTargets(req.getNotificationRoutineId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.ROUTINE_NOT_FOUND));
+
+            if (!routine.isOwner(userId)) throw new CustomException(ErrorCode.UNAUTHORIZED);
+            if (!routine.isCustom()) throw new CustomException(ErrorCode.INVALID_REQUEST);
+
+            CustomSupplement cs = routine.getCustomSupplement();
+
+            // 이름 충돌 방지: 같은 유저의 다른 cs가 동일 이름인지 체크
+            String newName = req.getName();
+            customRepo.findByUserIdAndName(userId, newName)
+                    .filter(other -> !other.getId().equals(cs.getId()))
+                    .ifPresent(conflict -> { throw new CustomException(ErrorCode.DUPLICATED_ROUTINE); });
+
+            // 기존 cs 엔티티 '값만' 변경 (INSERT 금지)
+            cs.update(newName, blankToNull(req.getImageUrl()));
+
+            // 스케줄 교체
+            routine.clearRoutineDetails();
+            req.getSchedules().forEach(s -> {
+                RoutineDetail d = RoutineDetail.builder()
+                        .dayOfWeek(s.getDayOfWeek())
+                        .time(s.getTime())
+                        .build();
+                routine.addRoutineDetail(d);
+            });
+            // @Transactional + 영속 상태 → save 호출 불필요
+        }
+
+        return RoutineRegisterResponseDto.builder()
+                .notificationRoutineId(routine.getId())
+                .supplementId(null) // 커스텀은 카탈로그 ID 없음
+                .supplementName(routine.getCustomSupplement().getName())
+                .supplementImageUrl(routine.getCustomSupplement().getImageUrl())
+                .schedules(routine.getRoutineDetails().stream()
+                        .map(d -> RoutineRegisterResponseDto.ScheduleResponse.builder()
+                                .dayOfWeek(d.getDayOfWeek())
+                                .time(d.getTime())
+                                .build())
+                        .toList())
+                .build();
+    }
+
+    private String blankToNull(String s) {
+        return (s == null || s.isBlank()) ? null : s;
+    }
+}


### PR DESCRIPTION
Close #170 

## 📝 작업 내용
사용자 정의(Custom) 영양제 복용 루틴 API 추가 및 수정
등록/수정 통합 API (POST /api/v1/notifications/routines/custom) 구현
notificationRoutineId 존재 시 → 수정
없을 시 → 신규 등록
@Transactional(readOnly = false) 적용하여 DB 쓰기 가능하도록 수정
삭제 API 구현 (DELETE /api/v1/notifications/routines/custom/{id})
현재 로그인 사용자 소유 여부 검증 후 삭제
조회 로직 보완
기존 getMyRoutines 조회 시 Custom 루틴도 포함되도록 수정
isTaken 필드 정상 반영 (IntakeRecord 기반)

## ✅ 변경 사항
커스텀 루틴 등록/수정 통합 처리
커스텀 루틴 삭제 기능 추가
루틴 목록 조회 시 커스텀 루틴 포함 및 isTaken 값 보완
@Transactional(readOnly = false) 적용으로 INSERT/UPDATE 정상 동작

## 💬 리뷰어에게
기존 NotificationRoutine 로직과 최대한 동일하게 맞춰 구현했습니다.