### PR TITLE
feat(#197): 임시 토큰 발급

### DIFF
--- a/src/main/java/com/vitacheck/config/SwaggerConfig.java
+++ b/src/main/java/com/vitacheck/config/SwaggerConfig.java
@@ -16,7 +16,10 @@ import org.springframework.web.method.HandlerMethod;
 import java.util.Arrays;
 import java.util.Optional;
 
-@OpenAPIDefinition(servers = {@Server(url = "https://vita-check.com", description = "Production Server")})
+@OpenAPIDefinition(servers = {
+        @Server(url = "http://localhost:8080", description = "Local Development Server"),
+        @Server(url = "https://vita-check.com", description = "Production Server")
+})
 @Configuration
 public class SwaggerConfig {
 

--- a/src/main/java/com/vitacheck/config/oAuth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/vitacheck/config/oAuth/OAuth2SuccessHandler.java
@@ -43,28 +43,11 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         if (user == null) {
             log.info("신규 사용자입니다. 추가 정보 입력 페이지로 리다이렉션합니다.");
 
-            // ✅✅✅ 핵심 수정 부분 시작 ✅✅✅
-            UriComponentsBuilder urlBuilder = UriComponentsBuilder.fromUriString("http://localhost:5173/social-signup")
-                    .queryParam("email", attributes.getEmail())
-                    .queryParam("fullName", attributes.getName())
-                    .queryParam("provider", attributes.getProvider())
-                    .queryParam("providerId", attributes.getProviderId());
-
-            // 네이버에서 받은 추가 정보가 있다면 URL 파라미터에 추가
-            if (attributes.getGender() != null) {
-                urlBuilder.queryParam("gender", attributes.getGender().name());
-            }
-            if (attributes.getBirthDate() != null) {
-                urlBuilder.queryParam("birthDate", attributes.getBirthDate().toString()); // yyyy-MM-dd 형식
-            }
-            if (attributes.getPhoneNumber() != null) {
-                urlBuilder.queryParam("phoneNumber", attributes.getPhoneNumber());
-            }
-
-            targetUrl = urlBuilder.build()
-                    .encode(StandardCharsets.UTF_8)
+            String tempToken = jwtUtil.createTempSocialToken(attributes);
+            targetUrl = UriComponentsBuilder.fromUriString("http://localhost:5173/social-signup")
+                    .queryParam("tempToken", tempToken)
+                    .build()
                     .toUriString();
-            // ✅✅✅ 핵심 수정 부분 끝 ✅✅✅
         }
         else {
             log.info("기존 사용자입니다. JWT 발급 후 메인 페이지로 이동합니다.");

--- a/src/main/java/com/vitacheck/controller/AuthController.java
+++ b/src/main/java/com/vitacheck/controller/AuthController.java
@@ -10,10 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Authentication", description = "사용자 인증 API (자체/소셜)")
 @RestController
@@ -46,15 +43,20 @@ public class AuthController {
         return CustomResponse.ok(tokenResponse);
     }
 
-    @Operation(summary = "소셜 회원가입", description = "소셜 로그인 후 추가 정보를 받아 최종 회원가입을 처리하고 JWT를 발급합니다.")
+    @Operation(summary = "소셜 회원가입", description = "소셜 로그인 후 임시 토큰과 추가 정보를 받아 최종 회원가입을 처리하고 JWT를 발급합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "소셜 회원가입 및 로그인 성공",
                     content = @Content(schema = @Schema(implementation = CustomResponse.class))),
-            @ApiResponse(responseCode = "400", description = "이미 가입된 회원이거나 필수 입력값이 누락된 경우", content = @Content)
+            @ApiResponse(responseCode = "400", description = "이미 가입된 회원이거나 필수 입력값이 누락된 경우", content = @Content),
+            @ApiResponse(responseCode = "401", description = "임시 토큰이 유효하지 않거나 만료된 경우", content = @Content) // 401 응답 설명 추가
     })
     @PostMapping("/social-signup")
-    public CustomResponse<UserDto.TokenResponse> socialSignUp(@RequestBody UserDto.SocialSignUpRequest request) {
-        UserDto.TokenResponse tokenResponse = userService.socialSignUp(request);
+    public CustomResponse<UserDto.TokenResponse> socialSignUp(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestBody UserDto.SocialSignUpRequest request
+    ) {
+        String tempToken = authorizationHeader.substring(7);
+        UserDto.TokenResponse tokenResponse = userService.socialSignUp(tempToken, request);
         return CustomResponse.ok(tokenResponse);
     }
 }

--- a/src/main/java/com/vitacheck/dto/UserDto.java
+++ b/src/main/java/com/vitacheck/dto/UserDto.java
@@ -63,6 +63,16 @@ public class UserDto {
         private Gender gender;
         private LocalDate birthDate;
         private String phoneNumber;
+
+        public SocialSignUpRequest(OAuthAttributes attributes) {
+            this.email = attributes.getEmail();
+            this.fullName = attributes.getName();
+            this.provider = attributes.getProvider();
+            this.providerId = attributes.getProviderId();
+            this.gender = attributes.getGender();
+            this.birthDate = attributes.getBirthDate();
+            this.phoneNumber = attributes.getPhoneNumber();
+        }
     }
 
     // JWT 토큰 응답 DTO


### PR DESCRIPTION
Close #197 

## 📝 작업 내용
신규 사용자의 소셜 로그인 시, 기존에 사용자 정보를 URL 쿼리 파라미터로 전달하던 방식의 보안 문제를 해결하고 전체적인 안정성을 개선했습니다.

Redis와 같은 외부 저장소 의존성 없이, 모든 소셔 프로필 정보를 암호화한 임시 JWT(tempToken)를 발급하여 프론트엔드와 안전하게 통신하는 Stateless 방식으로 회원가입 로직을 전면 수정했습니다. 또한, 이 과정에서 발생한 운영 환경의 ALB(로드밸런서) unhealthy 문제와 Swagger CORS 오류를 함께 해결하여 배포 안정성을 확보했습니다.

## ✅ 변경 사항
[x] 소셜 로그인 로직 변경 (Stateless JWT 도입)
- JwtUtil을 확장하여 소셜 프로필 정보 전체를 담는 임시 토큰 생성(createTempSocialToken) 및 추출(getSocialAttributesFromToken) 기능을 추가했습니다.
- OAuth2SuccessHandler가 신규 사용자 로그인 시, 위에서 생성한 임시 토큰을 URL 파라미터에 담아 프론트엔드로 리다이렉트하도록 수정했습니다.
- AuthController와 UserService가 최종 회원가입 시, Authorization 헤더의 임시 토큰과 RequestBody의 추가 정보를 조합하여 처리하도록 수정했습니다.

[x] ALB unhealthy 상태 및 504 오류 해결
- 로드밸런서의 상태 검사(Health Check) 전용 /health API 엔드포인트를 추가했습니다 (HealthCheckController).
- SecurityConfig에 /health 경로를 인증 없이 접근할 수 있도록 허용했습니다.
- EC2 보안 그룹 인바운드 규칙을 수정하여 로드밸런서 보안 그룹으로부터의 8080 포트 접근을 허용하도록 명확히 설정했습니다.

[x] Swagger CORS 오류 해결
- SecurityConfig의 CORS 설정에 운영 도메인(https://vita-check.com)을 허용 출처(Allowed Origin)로 추가했습니다.
- SwaggerConfig를 수정하여 로컬(http://localhost:8080)과 운영(https://vita-check.com) 서버를 모두 등록함으로써, 개발 및 테스트 환경에서 유연하게 사용할 수 있도록 개선했습니다.

## 💬 리뷰어에게
이번 PR을 통해 소셜 로그인 로직이 외부 의존성 없이 더 안전하고 간결한 구조로 변경되었습니다. 더불어, 가장 많은 시간을 소요했던 배포 환경의 네트워크 및 상태 검사 문제를 해결하여 앞으로의 배포 안정성이 크게 향상될 것으로 기대합니다. 주요 변경점인 JwtUtil과 OAuth2SuccessHandler의 로직을 중점적으로 검토해주시면 감사하겠습니다.