### PR TITLE
feat(#199): NotificationRoutine 토글 기능 추가

### DIFF
--- a/src/main/java/com/vitacheck/config/SecurityConfig.java
+++ b/src/main/java/com/vitacheck/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
             // login, signup
             "/api/v1/auth/signup",
             "/api/v1/auth/login",
+            "/api/v1/auth/social-signup",
             // OAuth2
             "/",
             "/login/**",

--- a/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationRoutineController.java
@@ -150,4 +150,20 @@ public class NotificationRoutineController {
         notificationRoutineCommandService.deleteRoutine(userId, routineId);
         return ResponseEntity.ok(CustomResponse.ok(null));
     }
+
+    @PatchMapping("/routines/{notificationRoutineId}/toggle")
+    @Operation(summary = "복용 루틴 알림 ON/OFF 토글", description = "특정 복용 루틴의 알림 활성화 상태(isEnabled)를 토글합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "토글 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "루틴을 찾을 수 없음")
+    })
+    public CustomResponse<RoutineResponseDto> toggleRoutineStatus(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable("notificationRoutineId") Long routineId
+    ) {
+        Long userId = userService.findIdByEmail(userDetails.getUsername());
+        RoutineResponseDto response = notificationRoutineCommandService.toggleRoutine(userId, routineId);
+        return CustomResponse.ok(response);
+    }
 }

--- a/src/main/java/com/vitacheck/domain/RoutineDetail.java
+++ b/src/main/java/com/vitacheck/domain/RoutineDetail.java
@@ -33,4 +33,6 @@ public class RoutineDetail extends BaseTimeEntity {
     public void setNotificationRoutine(NotificationRoutine routine) {
         this.notificationRoutine = routine;
     }
+
+
 }

--- a/src/main/java/com/vitacheck/domain/notification/NotificationRoutine.java
+++ b/src/main/java/com/vitacheck/domain/notification/NotificationRoutine.java
@@ -97,5 +97,9 @@ public class NotificationRoutine extends BaseTimeEntity {
         r.customSupplement = null;
         return r;
     }
+
+    public void toggleEnabled() {
+        this.isEnabled = !this.isEnabled;
+    }
 }
 

--- a/src/main/java/com/vitacheck/repository/IntakeRecordRepository.java
+++ b/src/main/java/com/vitacheck/repository/IntakeRecordRepository.java
@@ -18,4 +18,5 @@ public interface IntakeRecordRepository extends JpaRepository<IntakeRecord, Long
 
     boolean existsByNotificationRoutineIdAndUserIdAndDate(Long routineId, Long userId, LocalDate date);
 
+    boolean existsByNotificationRoutineAndUserAndDateAndIsTaken(NotificationRoutine routine, User user, LocalDate date, boolean isTaken);
 }

--- a/src/main/java/com/vitacheck/repository/NotificationRoutineRepository.java
+++ b/src/main/java/com/vitacheck/repository/NotificationRoutineRepository.java
@@ -63,5 +63,7 @@ public interface NotificationRoutineRepository extends JpaRepository<Notificatio
     """)
     Optional<NotificationRoutine> findByIdWithTargets(@Param("id") Long id);
 
+
+
     boolean existsByCustomSupplementId(Long customSupplementId);
 }


### PR DESCRIPTION
Close #199 

## 📝 작업 내용
사용자가 각 복용 루틴의 알림을 개별적으로 켜고 끌 수 있는 토글 기능을 추가했습니다. 사용자는 더 이상 필요하지 않은 알림을 비활성화하여 개인화된 알림 경험을 가질 수 있습니다.

## ✅ 변경 사항
NotificationRoutineController 추가:
- PATCH /api/v1/notifications/routines/{notificationRoutineId}/toggle 엔드포인트를 추가하여 특정 루틴의 알림 상태를 변경합니다.

NotificationRoutineCommandService 수정:
- toggleRoutine 비즈니스 로직을 추가하여 루틴의 isEnabled 상태를 변경하고, 변경된 결과를 RoutineResponseDto로 반환합니다.

NotificationRoutine 엔티티 수정:
- isEnabled 필드의 상태를 간편하게 변경할 수 있도록 toggleEnabled() 편의 메소드를 추가했습니다.

IntakeRecordRepository 수정:
- 섭취 여부를 더 명확하게 조회하기 위해 existsByNotificationRoutineAndUserAndDateAndIsTaken 메서드를 추가했습니다.