### PR TITLE
fix(#204): 응답처리 및 예외처리 통일

### DIFF
--- a/src/main/java/com/vitacheck/controller/NotificationRoutineCustomRestController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationRoutineCustomRestController.java
@@ -6,6 +6,8 @@ import com.vitacheck.global.apiPayload.CustomResponse;
 import com.vitacheck.service.NotificationRoutineCustomCommandService;
 import com.vitacheck.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +31,13 @@ public class NotificationRoutineCustomRestController {
 
     // 생성/수정 통합
     @Operation(summary = "커스텀 영양제 루틴 등록/수정(통합)")
+    @ApiResponses({ // <-- 이 부분 추가
+            @ApiResponse(responseCode = "201", description = "커스텀 루틴 생성 성공"),
+            @ApiResponse(responseCode = "200", description = "커스텀 루틴 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (예: 중복된 이름)"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않았거나 권한 없는 사용자"),
+            @ApiResponse(responseCode = "404", description = "사용자 또는 루틴을 찾을 수 없음")
+    })
     @PostMapping
     public ResponseEntity<CustomResponse<RoutineRegisterResponseDto>> upsert(
             @AuthenticationPrincipal UserDetails userDetails,

--- a/src/main/java/com/vitacheck/controller/SupplementController.java
+++ b/src/main/java/com/vitacheck/controller/SupplementController.java
@@ -56,6 +56,9 @@ public class SupplementController {
 
     @PostMapping("/by-purposes")
     @Operation(summary = "목적별 영양소 및 영양제 조회", description = "선택한 목적에 맞는 성분 및 관련 영양제를 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
     public CustomResponse<Map<String, SupplementByPurposeResponse>> getSupplementsByPurposes(
             @RequestBody SupplementPurposeRequest request
     ) {
@@ -65,6 +68,10 @@ public class SupplementController {
 
     @PostMapping("/{supplementId}/log-click")
     @Operation(summary = "영양제 클릭 기록", description = "사용자가 특정 영양제를 클릭했음을 기록하고 통계를 업데이트합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "클릭 기록 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 영양제를 찾을 수 없음")
+    })
     public CustomResponse<String> logSupplementClick(
             @AuthenticationPrincipal User user,
             @PathVariable Long supplementId
@@ -80,13 +87,17 @@ public class SupplementController {
     // 특정 영양제 상세 정보 반환 API
     @GetMapping
     @Operation(summary = "영양제 상세 조회", description = "supplementId로 상세 정보를 조회합니다.")
-    public SupplementDetailResponseDto getSupplement(@RequestParam Long id,
-                                                     @RequestHeader(name = "X-User-Id", required = false) Long userId) {
+    public SupplementDetailResponseDto getSupplement(
+            @RequestParam Long id,
+            @RequestHeader(name = "X-User-Id", required = false) Long userId) {
         return supplementService.getSupplementDetail(id, userId);
     }
 
     // 특정 브랜드 다른 영양제 목록 반환 API
     @GetMapping("/brand")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
     public Map<String, List<SupplementDto.SimpleResponse>> getByBrandId(@RequestParam Long id) {
         List<SupplementDto.SimpleResponse> list = supplementService.getSupplementsByBrandId(id);
         return Map.of("supplements", list);

--- a/src/main/java/com/vitacheck/service/SupplementService.java
+++ b/src/main/java/com/vitacheck/service/SupplementService.java
@@ -10,6 +10,8 @@ import com.vitacheck.domain.purposes.PurposeCategory;
 import com.vitacheck.domain.searchLog.SearchCategory;
 import com.vitacheck.domain.user.User;
 import com.vitacheck.dto.*;
+import com.vitacheck.global.apiPayload.CustomException;
+import com.vitacheck.global.apiPayload.code.ErrorCode;
 import com.vitacheck.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -140,7 +142,7 @@ public class SupplementService {
     @Transactional(readOnly = true)
     public SupplementDetailResponseDto getSupplementDetail(Long supplementId, Long userId) {
         Supplement supplement = supplementRepository.findById(supplementId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 영양제를 찾을 수 없습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.SUPPLEMENT_NOT_FOUND));
 
         boolean liked = (userId != null) && supplementLikeRepository.existsByUserIdAndSupplementId(userId, supplementId);
 


### PR DESCRIPTION
Close #204

## 📝 작업 내용
- 코드의 일관성 및 가독성을 높이기 위해 전역 예외 처리 방식을 통일하고, Swagger API 문서 명세를 보강하는 리팩토링을 진행했습니다.
- SupplementService의 예외를 CustomException으로 통일하고, 여러 컨트롤러에 누락된 @ApiResponses를 추가하여 API 문서의 완성도를 높였습니다

## ✅ 변경 사항
[x] SupplementService 예외 처리 통일
- getSupplementDetail 메서드에서 발생하던 IllegalArgumentException CustomException(ErrorCode.SUPPLEMENT_NOT_FOUND)으로 변경하여 프로젝트 전반의 예외 처리 일관성을 확보했습니다.

[x] SupplementController Swagger 문서 보강
- getSupplementsByPurposes, logSupplementClick, getByBrandId 메서드에 @ApiResponses를 추가하여 API 응답 케이스를 명확히 문서화했습니다.

[x] NotificationRoutineCustomRestController Swagger 문서 보강
- upsert 메서드에 @ApiResponses를 추가하여 커스텀 루틴 생성/수정 시 발생 가능한 예외 상황(중복, 권한 없음 등)을 상세히 명세했습니다.

## 💬 리뷰어에게
이번 리팩토링은 주로 코드의 일관성과 문서의 명확성을 높이는 데 중점을 두었습니다.

SupplementService의 예외 처리 방식이 다른 서비스들과 통일되었는지 확인 부탁드립니다.

각 컨트롤러에 추가된 @ApiResponses가 실제 로직과 일치하는지, 그리고 프론트엔드 개발자가 이해하기에 충분한지 검토해 주시면 감사하겠습니다.