### PR TITLE
feat(#212): 약관 수락 및 철회 기능 구현

### DIFF
--- a/src/main/java/com/vitacheck/config/SecurityConfig.java
+++ b/src/main/java/com/vitacheck/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
             "/api/v1/purposes/**",
             "/api/v1/supplements/**",
             "/api/v1/combinations/**",
+            "/api/v1/terms",
             "/api/v1/notification-settings/internal/trigger-notifications",
             "/health"
     };

--- a/src/main/java/com/vitacheck/controller/TermsController.java
+++ b/src/main/java/com/vitacheck/controller/TermsController.java
@@ -1,0 +1,69 @@
+package com.vitacheck.controller;
+
+import com.vitacheck.dto.TermsDto;
+import com.vitacheck.global.apiPayload.CustomResponse;
+import com.vitacheck.service.TermsService;
+import com.vitacheck.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "terms", description = "약관 관련 API")
+@RestController
+@RequestMapping("/api/v1/terms")
+@RequiredArgsConstructor
+public class TermsController {
+
+    private final TermsService termsService;
+    private final UserService userService;
+
+    @GetMapping
+    @Operation(summary = "전체 약관 목록 조회", description = "회원가입 또는 설정 화면에서 보여줄 모든 약관의 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    public CustomResponse<List<TermsDto.TermResponse>> getAllTerms() {
+        List<TermsDto.TermResponse> response = termsService.getAllTerms();
+        return CustomResponse.ok(response);
+    }
+
+    @PostMapping("/agreements")
+    @Operation(summary = "약관 동의", description = "로그인한 사용자가 아직 동의하지 않은 약관들에 대해 동의를 기록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "약관 동의 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    public CustomResponse<String> agreeToTerms(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody TermsDto.AgreementRequest request
+    ) {
+        Long userId = userService.findIdByEmail(userDetails.getUsername());
+        termsService.agreeToTerms(userId, request);
+        return CustomResponse.ok("약관 동의가 처리되었습니다.");
+    }
+
+    @DeleteMapping("/agreements")
+    @Operation(summary = "약관 동의 철회", description = "로그인한 사용자가 이전에 동의했던 약관들의 동의를 철회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "약관 동의 철회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    public CustomResponse<String> withdrawTerms(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Valid @RequestBody TermsDto.AgreementWithdrawalRequest request
+    ) {
+        Long userId = userService.findIdByEmail(userDetails.getUsername());
+        termsService.withdrawTerms(userId, request);
+        return CustomResponse.ok("약관 동의가 철회되었습니다.");
+    }
+}

--- a/src/main/java/com/vitacheck/dto/TermsDto.java
+++ b/src/main/java/com/vitacheck/dto/TermsDto.java
@@ -1,0 +1,55 @@
+package com.vitacheck.dto;
+
+import com.vitacheck.domain.Terms;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class TermsDto {
+
+    @Getter
+    @Builder
+    @Schema(description = "약관 조회 응답 DTO")
+    public static class TermResponse {
+        private Long id;
+        private String title;
+        private String content;
+        private String version;
+        private boolean isRequired;
+        private LocalDate effectiveDate;
+
+        public static TermResponse from(Terms term) {
+            return TermResponse.builder()
+                    .id(term.getId())
+                    .title(term.getTitle())
+                    .content(term.getContent())
+                    .version(term.getVersion())
+                    .isRequired(term.isRequired())
+                    .effectiveDate(term.getEffectiveDate())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "약관 동의 요청 DTO")
+    public static class AgreementRequest {
+        @NotEmpty(message = "하나 이상의 약관에 동의해야 합니다.")
+        @Schema(description = "사용자가 동의한 약관의 ID 목록", example = "[1, 2]")
+        private List<Long> agreedTermIds;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "약관 동의 철회 요청 DTO")
+    public static class AgreementWithdrawalRequest {
+        @NotEmpty(message = "하나 이상의 약관을 선택해야 합니다.")
+        @Schema(description = "사용자가 동의를 철회할 약관의 ID 목록", example = "[3]")
+        private List<Long> withdrawnTermIds;
+    }
+}

--- a/src/main/java/com/vitacheck/repository/TermsRepository.java
+++ b/src/main/java/com/vitacheck/repository/TermsRepository.java
@@ -1,0 +1,7 @@
+package com.vitacheck.repository;
+
+import com.vitacheck.domain.Terms;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TermsRepository extends JpaRepository<Terms, Long> {
+}

--- a/src/main/java/com/vitacheck/repository/UserTermsAgreementRepository.java
+++ b/src/main/java/com/vitacheck/repository/UserTermsAgreementRepository.java
@@ -1,0 +1,15 @@
+package com.vitacheck.repository;
+
+import com.vitacheck.domain.mapping.UserTermsAgreement;
+import com.vitacheck.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserTermsAgreementRepository extends JpaRepository<UserTermsAgreement, Long> {
+    // 사용자가 동의한 모든 약관 정보를 조회
+    List<UserTermsAgreement> findByUser(User user);
+
+    // ▼ [신규 추가] 사용자와 약관 ID 목록으로 동의 내역을 삭제하는 메서드 ▼
+    void deleteByUserAndTermsIdIn(User user, List<Long> termIds);
+}

--- a/src/main/java/com/vitacheck/service/TermsService.java
+++ b/src/main/java/com/vitacheck/service/TermsService.java
@@ -1,0 +1,102 @@
+package com.vitacheck.service;
+
+import com.vitacheck.domain.Terms;
+import com.vitacheck.domain.mapping.UserTermsAgreement;
+import com.vitacheck.domain.notification.NotificationSettings;
+import com.vitacheck.domain.notification.NotificationType;
+import com.vitacheck.domain.user.User;
+import com.vitacheck.dto.TermsDto;
+import com.vitacheck.global.apiPayload.CustomException;
+import com.vitacheck.global.apiPayload.code.ErrorCode;
+import com.vitacheck.repository.NotificationSettingsRepository;
+import com.vitacheck.repository.TermsRepository;
+import com.vitacheck.repository.UserRepository;
+import com.vitacheck.repository.UserTermsAgreementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TermsService {
+
+    private final TermsRepository termsRepository;
+    private final UserRepository userRepository;
+    private final UserTermsAgreementRepository userTermsAgreementRepository;
+    private final NotificationSettingsRepository notificationSettingsRepository;
+
+    public List<TermsDto.TermResponse> getAllTerms() {
+        return termsRepository.findAll().stream()
+                .map(TermsDto.TermResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void agreeToTerms(Long userId, TermsDto.AgreementRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 1. 사용자가 이미 동의한 약관 ID 목록을 조회
+        Set<Long> alreadyAgreedTermIds = userTermsAgreementRepository.findByUser(user).stream()
+                .map(agreement -> agreement.getTerms().getId())
+                .collect(Collectors.toSet());
+
+        // 2. 요청된 약관 ID 중에서, 아직 동의하지 않은 약관 ID만 필터링
+        List<Long> newTermIdsToAgree = request.getAgreedTermIds().stream()
+                .filter(id -> !alreadyAgreedTermIds.contains(id))
+                .collect(Collectors.toList());
+
+        // 3. 새로 동의할 약관이 없다면 아무것도 하지 않음
+        if (newTermIdsToAgree.isEmpty()) {
+            return;
+        }
+
+        List<Terms> termsToAgree = termsRepository.findAllById(newTermIdsToAgree);
+
+        // 4. 마케팅 약관에 새로 동의했는지 확인하고, 알림 설정 ON
+        boolean marketingAgreed = termsToAgree.stream()
+                .anyMatch(term -> "마케팅 목적의 개인정보 수집 및 이용에 대한 동의".equals(term.getTitle()));
+
+        if (marketingAgreed) {
+            updateMarketingSettings(user, true);
+        }
+
+        List<UserTermsAgreement> agreements = termsToAgree.stream()
+                .map(term -> UserTermsAgreement.builder().user(user).terms(term).build())
+                .collect(Collectors.toList());
+
+        userTermsAgreementRepository.saveAll(agreements);
+    }
+
+    @Transactional
+    public void withdrawTerms(Long userId, TermsDto.AgreementWithdrawalRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<Long> termIdsToWithdraw = request.getWithdrawnTermIds();
+        List<Terms> termsToWithdraw = termsRepository.findAllById(termIdsToWithdraw);
+
+        // 1. 마케팅 약관을 철회하는지 확인하고, 알림 설정 OFF
+        boolean marketingWithdrawn = termsToWithdraw.stream()
+                .anyMatch(term -> "마케팅 목적의 개인정보 수집 및 이용에 대한 동의".equals(term.getTitle()));
+
+        if (marketingWithdrawn) {
+            updateMarketingSettings(user, false);
+        }
+
+        // 2. DB에서 동의 내역 삭제
+        userTermsAgreementRepository.deleteByUserAndTermsIdIn(user, termIdsToWithdraw);
+    }
+
+    private void updateMarketingSettings(User user, boolean isEnabled) {
+        List<NotificationSettings> settings = notificationSettingsRepository.findByUser(user);
+        settings.stream()
+                .filter(s -> s.getType() == NotificationType.EVENT)
+                .forEach(s -> s.setIsEnabled(isEnabled));
+    }
+}


### PR DESCRIPTION
Close #212 

## 📝 작업 내용

회원가입 및 사용자 설정에 필요한 **약관 조회, 동의, 철회 기능**을 구현했습니다. 사용자가 약관 내용을 확인하고, 필수 및 선택 약관에 대해 동의 의사를 명확히 기록하며, 필요시 동의를 철회할 수 있는 시스템의 기반을 마련했습니다.

<br>

## ✅ 변경 사항

### **1. 약관 관리 API 구현**
-   **`GET /api/v1/terms`**: DB에 저장된 모든 약관의 목록을 조회하는 API를 구현했습니다. `SecurityConfig`에 해당 경로를 `permitAll`로 설정하여 비로그인 사용자도 접근 가능합니다.
-   **`POST /api/v1/terms/agreements`**: 사용자가 **아직 동의하지 않은** 약관에 대해서만 신규 동의를 기록하는 API를 구현했습니다.
    -   기존에 동의한 약관 ID가 요청에 포함되어도 중복으로 저장되지 않도록 방지 로직을 추가했습니다.
-   **`DELETE /api/v1/terms/agreements`**: 사용자가 기존에 동의했던 약관을 철회하는 API를 신규 구현했습니다.

### **2. 마케팅 약관 - 알림 설정 연동**
-   **동의 시**: `TermsService`에서 사용자가 '마케팅 목적 개인정보 수집 동의' 약관에 동의하는 경우, `notification_settings` 테이블에서 해당 사용자의 `EVENT` 관련 알림 설정을 모두 `true`(활성화)로 자동 업데이트하도록 구현했습니다.
-   **철회 시**: 반대로 마케팅 약관 동의를 철회하면, 관련 알림 설정을 모두 `false`(비활성화)로 업데이트하도록 구현했습니다.

### **3. 엔티티 및 데이터 구조**
-   `Terms` (약관 원본), `UserTermsAgreement` (사용자-약관 동의 매핑) 엔티티 및 관련 DTO와 Repository를 추가했습니다.
-   마케팅 약관과 같이 표 형식이 필요한 내용은 HTML `<table>` 태그를 사용하여 `content` 필드에 저장하는 방식을 채택했습니다.

<br>

## 💬 리뷰어에게

-   이번 PR은 회원가입의 핵심 선행 조건인 약관 동의 로직 전반을 다루고 있습니다.
-   `TermsService`의 `agreeToTerms`와 `withdrawTerms` 메서드에서 중복 동의 방지 및 동의 철회 로직이 정확하게 동작하는지 확인 부탁드립니다.
-   마케팅 약관 동의/철회 시 `notification_settings` 테이블이 올바르게 업데이트되는지 검토해 주시면 감사하겠습니다.