### PR TITLE
feat(#218): 2단계로 회원가입 분리

### DIFF
--- a/src/main/java/com/vitacheck/config/SecurityConfig.java
+++ b/src/main/java/com/vitacheck/config/SecurityConfig.java
@@ -35,7 +35,8 @@ public class SecurityConfig {
             // Swagger UI v3
             "/v3/api-docs/**",
             "/swagger-ui/**",
-            // login, signup
+            // login, signup,
+            "/api/v1/auth/pre-signup",
             "/api/v1/auth/signup",
             "/api/v1/auth/login",
             "/api/v1/auth/social-signup",

--- a/src/main/java/com/vitacheck/controller/AuthController.java
+++ b/src/main/java/com/vitacheck/controller/AuthController.java
@@ -4,11 +4,13 @@ import com.vitacheck.dto.UserDto;
 import com.vitacheck.global.apiPayload.CustomResponse;
 import com.vitacheck.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,14 +22,21 @@ public class AuthController {
 
     private final UserService userService;
 
-    @Operation(summary = "자체 회원가입", description = "이메일, 비밀번호 및 사용자 추가 정보를 이용해 가입을 요청합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
-            @ApiResponse(responseCode = "400", description = "입력 값 형식 오류 또는 이메일 중복", content = @Content)
-    })
+    @Operation(summary = "1단계 임시 회원가입 (임시 토큰 발급)", description = "이메일, 비밀번호, 닉네임, 약관 동의 내역을 받아 2단계에서 사용할 임시 토큰을 발급합니다.")
+    @PostMapping("/pre-signup")
+    public CustomResponse<String> preSignUp(@RequestBody @Valid UserDto.PreSignUpRequest request) {
+        String preSignupToken = userService.preSignUp(request);
+        return CustomResponse.ok(preSignupToken);
+    }
+
+    @Operation(summary = "2단계 최종 회원가입", description = "이름, 성별, 생년월일, 전화번호와 임시 토큰을 받아 최종 회원가입을 완료합니다.")
     @PostMapping("/signup")
-    public CustomResponse<String> signUp(@RequestBody UserDto.SignUpRequest request) {
-        userService.signUp(request);
+    public CustomResponse<String> signUp(
+            @Parameter(description = "1단계에서 발급받은 임시 토큰") @RequestHeader("Authorization") String authorizationHeader,
+            @RequestBody @Valid UserDto.SignUpRequest finalRequest
+    ) {
+        String preSignupToken = authorizationHeader.substring(7); // "Bearer " 제거
+        userService.signUp(preSignupToken, finalRequest);
         return CustomResponse.created("회원가입이 성공적으로 완료되었습니다.");
     }
 

--- a/src/main/java/com/vitacheck/dto/UserDto.java
+++ b/src/main/java/com/vitacheck/dto/UserDto.java
@@ -3,37 +3,42 @@ package com.vitacheck.dto;
 import com.vitacheck.domain.user.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class UserDto {
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "1단계 임시 회원가입 요청 DTO")
+    public static class PreSignUpRequest {
+        @Schema(description = "사용자 이메일 주소", example = "user@vitacheck.com")
+        private String email;
+        @Schema(description = "사용자 비밀번호 (8자 이상)", example = "password123!")
+        private String password;
+        @Schema(description = "사용할 닉네임", example = "행복한쿼카")
+        private String nickname;
+        @NotEmpty
+        @Schema(description = "사용자가 동의한 약관의 ID 목록", example = "[1, 2, 3]")
+        private List<Long> agreedTermIds;
+    }
 
     // 자체 회원가입 요청 DTO
     @Getter
     @NoArgsConstructor
-    @Schema(description = "자체 회원가입 요청 DTO")
+    @Schema(description = "2단계 최종 회원가입 요청 DTO")
     public static class SignUpRequest {
-        @Schema(description = "사용자 이메일 주소", example = "user@vitacheck.com")
-        private String email;
-
-        @Schema(description = "사용자 비밀번호 (8자 이상)", example = "password123!")
-        private String password;
-
         @Schema(description = "사용자 실명", example = "홍길동")
         private String fullName;
-
-        @Schema(description = "사용할 닉네임", example = "행복한쿼카")
-        private String nickname;
-
         @Schema(description = "성별", example = "MALE")
         private Gender gender;
-
         @Schema(description = "생년월일", example = "2000-01-01")
         private LocalDate birthDate;
-
         @Schema(description = "휴대폰 번호", example = "010-1234-5678")
         private String phoneNumber;
     }


### PR DESCRIPTION
Close #218 

## 📝 작업 내용

사용자가 여러 페이지에 걸쳐 정보를 입력하는 **2단계 회원가입 프로세스**를 구현했습니다. 페이지 이동 시 1단계에서 입력된 정보(기본 정보, 약관 동의 내역)가 유실되거나 위변조되는 것을 방지하기 위해 **임시 JWT 토큰**을 발급하는 방식을 채택했습니다. 최종적으로 모든 정보를 취합하여 사용자 생성과 약관 동의 기록을 **하나의 트랜잭션**으로 안전하게 처리합니다.

<br>

## ✅ 변경 사항

### **1. DTO (Data Transfer Object) 분리**
-   `UserDto.PreSignUpRequest`: 1단계 요청(이메일, 비밀번호, 닉네임, 약관 동의 ID 목록)을 처리하는 DTO를 신규 생성했습니다.
-   `UserDto.SignUpRequest`: 2단계 추가 정보 요청(이름, 성별, 생년월일, 전화번호)을 처리하도록 기존 DTO를 수정했습니다.

### **2. 임시 토큰 로직 구현 (`JwtUtil`)**
-   `createPreSignupToken`: 1단계 요청 정보를 담아 유효기간 10분의 임시 JWT 토큰을 생성하는 메서드를 추가했습니다.
-   `getClaimsFromPreSignupToken`: 임시 토큰의 유효성을 검증하고 저장된 정보를 안전하게 복원하는 메서드를 추가했습니다.

### **3. API 엔드포인트 구현 (`AuthController`)**
-   `POST /api/v1/auth/pre-signup`: 1단계 정보를 받아 임시 토큰을 발급하는 API를 신규 구현했습니다.
-   `POST /api/v1/auth/signup`: `@RequestHeader`로 임시 토큰을, `@RequestBody`로 2단계 추가 정보를 받아 최종 회원가입을 처리하도록 기존 API를 수정했습니다.

### **4. 서비스 로직 구현 (`UserService`)**
-   `preSignUp`: 1단계 요청을 검증하고 임시 토큰을 생성하는 로직을 구현했습니다.
-   `signUp`: 임시 토큰에서 1단계 정보를, 요청 본문에서 2단계 정보를 가져와 **하나의 트랜잭션 내에서** 사용자 생성, 약관 동의 기록, 기본 알림 설정 생성을 모두 처리하도록 구현했습니다.

### **5. 보안 설정 및 버그 수정**
-   `JwtAuthenticationFilter`: 회원가입 관련 경로들(`/pre-signup`, `/signup`)이 일반 인증 필터를 거치지 않도록 예외 처리하여, 임시 토큰과 인증 토큰의 충돌을 방지했습니다.
-   토큰에서 `agreedTermIds`를 추출할 때 발생하던 `Integer` -> `Long` 타입 변환 오류(`ClassCastException`)를 해결했습니다.
-   토큰 값에 공백이 포함될 경우 발생하던 `DecodingException`을 `JwtUtil.validateToken`에서 처리하도록 개선하여 500 에러를 방지했습니다.

<br>

## 💬 리뷰어에게

-   이번 PR은 회원가입의 핵심 플로우를 다루고 있으므로, 1단계부터 2단계까지의 전체적인 흐름을 중점적으로 리뷰 부탁드립니다.
-   특히 `UserService`의 `signUp` 메서드가 두 단계의 정보를 올바르게 취합하여 하나의 트랜잭션으로 안전하게 처리하는지 확인해 주시면 감사하겠습니다.
-   `JwtAuthenticationFilter`에 예외 경로를 추가한 것이 다른 인증 로직에 영향을 주지 않는지도 함께 검토해 주시면 좋겠습니다.