### PR TITLE
[BUG]#223 성분 이미지 url 안나오는 오류 추가 수정

### DIFF
--- a/src/main/java/com/vitacheck/dto/IngredientResponseDTO.java
+++ b/src/main/java/com/vitacheck/dto/IngredientResponseDTO.java
@@ -41,6 +41,7 @@ public class IngredientResponseDTO {
         private Long id;
         private String name;
         private String coupangUrl;
+        private String imageUrl;
     }
     
 

--- a/src/main/java/com/vitacheck/service/IngredientService.java
+++ b/src/main/java/com/vitacheck/service/IngredientService.java
@@ -177,7 +177,8 @@ public class IngredientService {
                             IngredientResponseDTO.IngredientSupplement.class,
                             s.id.as("id"),
                             s.name.as("name"),
-                            s.coupangUrl.as("coupangUrl")
+                            s.coupangUrl.as("coupangUrl"),
+                            s.imageUrl.as("imageUrl")
                     ))
                     .from(si)
                     .join(s).on(si.supplement.id.eq(s.id))


### PR DESCRIPTION
Close #223 

## 📝 작업 내용
성분 이미지 url 안나오는 오류 추가 수정

## ✅ 변경 사항
- [x]이미지 url 추가 (IngredientDTO, IngredientService 수정)


## 📷 스크린샷 (선택)
<img width="864" height="272" alt="image" src="https://github.com/user-attachments/assets/b41b0379-af91-4fa4-9642-bbda8b2604e2" />

## 💬 리뷰어에게