### PR TITLE
feat(#243):인기 영양제 API 성별 필터링 추가

### DIFF
--- a/src/main/java/com/vitacheck/controller/SupplementController.java
+++ b/src/main/java/com/vitacheck/controller/SupplementController.java
@@ -1,5 +1,6 @@
 package com.vitacheck.controller;
 
+import com.vitacheck.domain.user.Gender;
 import com.vitacheck.domain.user.User;
 import com.vitacheck.dto.*;
 import com.vitacheck.global.apiPayload.CustomException;
@@ -99,7 +100,7 @@ public class SupplementController {
         return supplementService.getSupplementDetailById(id);
     }
 
-    @Operation(summary = "연령대별 인기 영양제 조회", description = "검색 횟수를 기준으로 연령대별 인기 영양제 순위를 조회합니다.")
+    @Operation(summary = "연령대/성별별 인기 영양제 조회", description = "검색 횟수를 기준으로 연령대별 인기 영양제 순위를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "연령대별 인기 영양제 조회 성공",
                     content = @Content(examples = @ExampleObject(value = "{\"isSuccess\":true,\"code\":\"COMMON200\",\"message\":\"성공적으로 요청을 수행했습니다.\",\"result\":\"FCM 토큰이 업데이트되었습니다.\"}"))),
@@ -111,19 +112,23 @@ public class SupplementController {
 
     })
     @Parameters({
-            @Parameter(name = "ageGroup", description = "조회할 연령대", required = true, example = "20대",
-                    // 'ageGroup'에 들어올 수 있는 값들을 명시하여 드롭다운 형태로 보여줍니다.
+            @Parameter(name = "ageGroup", description = "조회할 연령대", example = "20대",
                     schema = @Schema(type = "string", allowableValues = {"10대", "20대", "30대", "40대", "50대", "60대 이상", "전체"})),
+            @Parameter(name = "gender", description = "조회할 성별", example = "MALE",
+                    schema = @Schema(type = "string", allowableValues = {"MALE", "FEMALE", "전체"})), // ✅ Gender 파라미터 명세 추가
             @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", example = "0"),
             @Parameter(name = "size", description = "한 페이지에 보여줄 아이템 수", example = "10"),
-            @Parameter(name = "sort", hidden = true) // 이 API는 인기순으로 정렬이 고정되므로 sort 파라미터는 숨김 처리합니다.
+            @Parameter(name = "sort", hidden = true)
     })
     @GetMapping("/popular-supplements")
     public CustomResponse<Page<PopularSupplementDto>> getPopularSupplements(
-            @RequestParam String ageGroup,
-            @Parameter(hidden = true)Pageable pageable
+            @RequestParam(defaultValue = "전체") String ageGroup,
+            @RequestParam(defaultValue = "전체") String gender,
+            @Parameter(hidden = true) Pageable pageable
     ) {
-        Page<PopularSupplementDto> result = supplementService.findPopularSupplements(ageGroup, pageable);
+        Gender genderEnum = "전체".equalsIgnoreCase(gender) ? Gender.NONE : Gender.valueOf(gender.toUpperCase());
+
+        Page<PopularSupplementDto> result = supplementService.findPopularSupplements(ageGroup, genderEnum, pageable);
         return CustomResponse.ok(result);
     }
 }

--- a/src/main/java/com/vitacheck/repository/SearchLogRepositoryCustom.java
+++ b/src/main/java/com/vitacheck/repository/SearchLogRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.vitacheck.repository;
 
 import com.querydsl.core.Tuple;
+import com.vitacheck.domain.user.Gender;
 import com.vitacheck.dto.PopularIngredientDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,6 +10,6 @@ import java.util.List;
 
 public interface SearchLogRepositoryCustom {
     List<Tuple> findPopularIngredientsByAgeGroup(Integer startAge, Integer endAge, int limit);
-    Page<Tuple> findPopularSupplements(Integer startAge, Integer endAge, Pageable pageable);
+    Page<Tuple> findPopularSupplements(Integer startAge, Integer endAge, Gender gender, Pageable pageable);
 
 }

--- a/src/main/java/com/vitacheck/service/SupplementService.java
+++ b/src/main/java/com/vitacheck/service/SupplementService.java
@@ -9,6 +9,7 @@ import com.vitacheck.domain.mapping.SupplementIngredient;
 import com.vitacheck.domain.purposes.AllPurpose;
 import com.vitacheck.domain.purposes.PurposeCategory;
 import com.vitacheck.domain.searchLog.SearchCategory;
+import com.vitacheck.domain.user.Gender;
 import com.vitacheck.domain.user.User;
 import com.vitacheck.dto.*;
 import com.vitacheck.global.apiPayload.CustomException;
@@ -244,7 +245,7 @@ public class SupplementService {
 
     private final SearchLogRepository searchLogRepository;
 
-    public Page<PopularSupplementDto> findPopularSupplements(String ageGroup, Pageable pageable) {
+    public Page<PopularSupplementDto> findPopularSupplements(String ageGroup, Gender gender, Pageable pageable) {
         // 1. 연령대 문자열을 숫자 범위로 변환
         Integer startAge = null;
         Integer endAge = null;
@@ -267,7 +268,7 @@ public class SupplementService {
         }
 
         // 2. Repository 호출하여 Tuple 페이지를 받음
-        Page<Tuple> resultPage = searchLogRepository.findPopularSupplements(startAge, endAge, pageable);
+        Page<Tuple> resultPage = searchLogRepository.findPopularSupplements(startAge, endAge,gender, pageable);
 
         // 3. Tuple 페이지를 DTO 페이지로 변환
         return resultPage.map(tuple -> {


### PR DESCRIPTION
Close #243

📝 작업 내용
기존에 연령대별로만 조회가 가능했던 '인기 영양제 조회 API'에 성별 필터링 기능을 추가했습니다.

이제 ageGroup과 gender 파라미터를 조합하여 "20대 여성이 많이 찾는 영양제"와 같이 더 세분화된 통계 조회가 가능합니다.

✅ 변경 사항
[x] StatisticsController: gender 요청 파라미터 및 Swagger 명세 추가

[x] StatisticsService: findPopularSupplements 메소드에 gender 파라미터 전달 로직 추가

[x] SearchLogRepository: Querydsl을 사용하여 gender를 동적으로 필터링하는 WHERE 조건 추가

📷 스크린샷 (선택)

💬 리뷰어에게