### PR TITLE
fix(#267): Page -> Slice로 변경

### DIFF
--- a/src/main/java/com/vitacheck/controller/SupplementController.java
+++ b/src/main/java/com/vitacheck/controller/SupplementController.java
@@ -21,6 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
@@ -79,17 +80,15 @@ public class SupplementController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
-    public CustomResponse<Page<IngredientPurposeBucket>> getSupplementsByPurposes(
+    public CustomResponse<Slice<IngredientPurposeBucket>> getSupplementsByPurposes(
             @RequestBody SupplementPurposeRequest request,
             @org.springdoc.core.annotations.ParameterObject Pageable pageable
     ) {
         // ① 요청 들어온 순간 Pageable 값 확인
         log.info("[Controller] page={}, size={}, sort={}",
                 pageable.getPageNumber(), pageable.getPageSize(), pageable.getSort());
-        Page<IngredientPurposeBucket> page = supplementService.getSupplementsByPurposesPaged(request, pageable);
-        log.info("[Controller] returned content.size={}, totalElements={}, totalPages={}",
-                page.getContent().size(), page.getTotalElements(), page.getTotalPages());
-        return CustomResponse.ok(page);
+        Slice<IngredientPurposeBucket> slice = supplementService.getSupplementsByPurposesPaged(request, pageable);
+        return CustomResponse.ok(slice);
     }
 
 

--- a/src/main/java/com/vitacheck/repository/PurposeQueryRepository.java
+++ b/src/main/java/com/vitacheck/repository/PurposeQueryRepository.java
@@ -3,6 +3,7 @@ package com.vitacheck.repository;
 import com.vitacheck.domain.purposes.AllPurpose;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -16,7 +17,7 @@ public interface PurposeQueryRepository {
      * 영양소(ingredient)들 중에서, 성분 ID만 얇게 페이지네이션하여 반환
      * 정렬 기준: ingredient.name ASC, ingredient.id ASC
      */
-    Page<Long> findIngredientIdPageByPurposes(List<AllPurpose> purposes, Pageable pageable);
+    Slice<Long> findIngredientIdPageByPurposes(List<AllPurpose> purposes, Pageable pageable);
 
     /**
      * 주어진 성분 ID 집합에 대해, (옵션) 목적 필터를 적용하여


### PR DESCRIPTION
Close #267 

## 📝 작업 내용
- 문제 상황: 목적별 영양제 조회 API에서 사용자가 건강 목적을 2개 이상 선택할 경우, DB에서 타임아웃이 발생하여 API가 실패하는 문제가 있었습니다.
- 원인 분석: 페이지네이션을 위해 실행되는 countDistinct 쿼리가 다중 목적 조건 하에서 DB에 과도한 부하를 주는 것이 원인이었습니다.
- 해결 방안: 전체 개수를 세는 Page 기반 페이지네이션 대신, "다음 페이지 존재 여부"만 확인하는 Slice (커서 기반) 페이지네이션을 도입하여 불필요한 count 쿼리를 제거했습니다.

## ✅ 변경 사항
[x] Repository 계층 수정:
- PurposeQueryRepository의 findIngredientIdPageByPurposes 메소드 반환 타입을 Page<Long>에서 Slice<Long>으로 변경했습니다.
- count 쿼리 로직을 완전히 제거하고, limit에 pageSize + 1을 적용하여 다음 페이지 존재 여부를 확인하도록 구현했습니다.

[x] Service 계층 수정:
- SupplementService의 getSupplementsByPurposesPaged 메소드가 Slice 객체를 반환받아 처리하도록 수정했습니다.
- 최종 반환 타입 또한 Slice<IngredientPurposeBucket>으로 변경하여, 전체 개수 정보 없이 hasNext 정보만 전달하도록 명확히 했습니다.

[x] Controller 계층 수정:
- SupplementController의 getSupplementsByPurposes 엔드포인트가 Slice 객체를 받아 CustomResponse로 감싸 반환하도록 수정했습니다.