### PR TITLE
feat(#276): 리프레시 토큰으로 액티브 토큰 재발급 및 RoutineToggle에 isEnabled 추가

### DIFF
--- a/src/main/java/com/vitacheck/config/SwaggerConfig.java
+++ b/src/main/java/com/vitacheck/config/SwaggerConfig.java
@@ -17,7 +17,6 @@ import java.util.Arrays;
 import java.util.Optional;
 
 @OpenAPIDefinition(servers = {
-        @Server(url = "http://localhost:8080", description = "Local Development Server"),
         @Server(url = "https://vita-check.com", description = "Production Server")
 })
 @Configuration

--- a/src/main/java/com/vitacheck/controller/AuthController.java
+++ b/src/main/java/com/vitacheck/controller/AuthController.java
@@ -68,4 +68,11 @@ public class AuthController {
         UserDto.TokenResponse tokenResponse = userService.socialSignUp(tempToken, request);
         return CustomResponse.ok(tokenResponse);
     }
+
+    @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.")
+    @PostMapping("/refresh")
+    public CustomResponse<UserDto.TokenResponse> refreshAccessToken(@RequestBody UserDto.RefreshTokenRequest request) {
+        UserDto.TokenResponse tokenResponse = userService.refreshAccessToken(request);
+        return CustomResponse.ok(tokenResponse);
+    }
 }

--- a/src/main/java/com/vitacheck/dto/RoutineRegisterResponseDto.java
+++ b/src/main/java/com/vitacheck/dto/RoutineRegisterResponseDto.java
@@ -25,6 +25,8 @@ public class RoutineRegisterResponseDto {
 
     private List<ScheduleResponse> schedules;
 
+    private Boolean isEnabled;
+
     @Getter
     @Builder
     public static class ScheduleResponse {

--- a/src/main/java/com/vitacheck/dto/UserDto.java
+++ b/src/main/java/com/vitacheck/dto/UserDto.java
@@ -133,4 +133,10 @@ public class UserDto {
 
         private String profileImageUrl;
     }
+
+    @Getter
+    @NoArgsConstructor
+    public static class RefreshTokenRequest {
+        private String refreshToken;
+    }
 }

--- a/src/main/java/com/vitacheck/service/NotificationRoutineCommandService.java
+++ b/src/main/java/com/vitacheck/service/NotificationRoutineCommandService.java
@@ -163,6 +163,7 @@ public class NotificationRoutineCommandService {
                 .supplementName(supplementName)
                 .supplementImageUrl(supplementImageUrl)
                 .isTaken(isTaken)
+                .isEnabled(routine.isEnabled())
                 .schedules(scheduleResponses)
                 .build();
     }

--- a/src/main/java/com/vitacheck/service/UserService.java
+++ b/src/main/java/com/vitacheck/service/UserService.java
@@ -211,4 +211,14 @@ public class UserService {
         return user.getProfileUrl();
     }
 
+    public UserDto.TokenResponse refreshAccessToken(UserDto.RefreshTokenRequest request) {
+        String refreshToken = request.getRefreshToken();
+        if (!jwtUtil.validateToken(refreshToken)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+        String email = jwtUtil.getEmailFromToken(refreshToken);
+        String newAccessToken = jwtUtil.createAccessToken(email);
+        return new UserDto.TokenResponse(newAccessToken, refreshToken);
+    }
+
 }


### PR DESCRIPTION
Close #276 

## 📝 작업 내용
액세스 토큰 만료 시 재발급을 위한 리프레시 토큰 API를 추가하고, 사용성 개선을 위해 루틴 토글 API의 응답값을 수정했습니다.

## ✅ 변경 사항
리프레시 토큰 API 추가
- POST /api/v1/auth/refresh 엔드포인트를 추가하여, 유효한 리프레시 토큰으로 새로운 액세스 토큰을 발급받을 수 있도록 구현했습니다.
- 관련 로직 처리를 위해 UserService에 refreshAccessToken 메서드를 추가했습니다.
- 리프레시 토큰을 담아 요청할 RefreshTokenRequest DTO를 UserDto 내에 추가했습니다.

루틴 토글 API 응답 개선
- NotificationRoutineCommandService의 toggleRoutine 메서드가 반환하는 RoutineResponseDto에 현재 루틴의 활성화 상태를 나타내는 isEnabled 필드를 추가했습니다.