### PR TITLE
[REFRACTOR#277] 통합 검색 로직 수정 + cursor 페이지 제너레이션 + 검색 기록

### DIFF
--- a/src/main/java/com/vitacheck/controller/IngredientController.java
+++ b/src/main/java/com/vitacheck/controller/IngredientController.java
@@ -76,6 +76,10 @@ public class IngredientController {
             summary = "성분 관련 영양제 조회 (cursor 기반) API By 박지영",
             description = """
         성분 관련 영양제를 cursor기반으로 반환합니다..
+        
+        cursor 처음은 빈칸 또는 0으로 호출하면 됩니다. 그 이후 부터는 nextCursor 값이 아닌 '마지막으로 조회된 ID'를 넣어주면 됩니다.
+                    
+        nextcursor가 null이면 다음 페이지가 없다는 뜻입니다.
         """
 
     )

--- a/src/main/java/com/vitacheck/controller/SearchController.java
+++ b/src/main/java/com/vitacheck/controller/SearchController.java
@@ -2,10 +2,13 @@ package com.vitacheck.controller;
 
 import com.vitacheck.config.jwt.CustomUserDetails;
 import com.vitacheck.domain.user.User;
+import com.vitacheck.dto.IngredientResponseDTO;
 import com.vitacheck.dto.SupplementDto;
 import com.vitacheck.global.apiPayload.CustomException;
 import com.vitacheck.global.apiPayload.CustomResponse;
+import com.vitacheck.service.IngredientService;
 import com.vitacheck.service.SearchLogService;
+import com.vitacheck.service.SupplementService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -32,6 +35,8 @@ public class SearchController {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final SearchLogService searchLogService;
+    private final IngredientService ingredientService;
+    private final SupplementService supplementService;
 
     @Operation(
             summary = "인기 검색어 조회 API By 박지영",

--- a/src/main/java/com/vitacheck/controller/SupplementController.java
+++ b/src/main/java/com/vitacheck/controller/SupplementController.java
@@ -61,6 +61,47 @@ public class SupplementController {
         return CustomResponse.ok(response);
     }
 
+    @GetMapping("/search-cursor")
+    @Operation(
+            summary = "영양제 제품 검색 API (Cursor 기반 페이지네이션) By 박지영",
+            description = """
+                    키워드와 연관된 모든 영양제 제품이 조회됩니다. (성분, 브랜드, 제품 이름 등)
+                    
+                    ex. 유산균 → 제품 이름에 유산균 포함된 영양제, 유산균을 성분으로 포함하는 영양제 등 모두 조회됩니다.
+                    
+                    검색 키워드로 제품을 cursor 기반 페이지네이션으로 조회, 정렬은 인기도 높은 순으로(인기도=클릭수+검색수) 
+                    
+                    cursor 처음은 빈칸인채로 호출하면 됩니다. 그 이후 부터는 nextCursor 값이 아닌 '마지막으로 조회된 cursorID'를 넣어주면 됩니다. 
+                    
+                    nextcursor가 null이면 다음 페이지가 없다는 뜻입니다."""
+    )
+    public CustomResponse<SupplementDto.KeywordSearchSupplementBasedCursor> searchSupplements(
+            @Parameter(name = "keyword", description = "검색 키워드", example = "유산균")
+            @RequestParam String keyword,
+            @Parameter(name = "cursorId", description = "마지막 조회된 아이디 (인기도 *1000000 + supplementId)", example = "")
+            @RequestParam(required = false) Long cursorId,
+            @Parameter(name = "size", description = "가져올 데이터 개수", example = "40")
+            @RequestParam(defaultValue = "40") int size
+    ) {
+        SupplementDto.KeywordSearchSupplementBasedCursor responseDto =
+                supplementService.searchSupplements(keyword, cursorId,size);
+
+        return CustomResponse.ok(responseDto);
+    }
+
+    @Operation(
+            summary = "제품 검색 기록 API By 박지영",
+            description = " 검색에서 검색한 키워드를 기록합니다. 제품 검색을 사용할 때만 이 api를 추가로 사용해주시면 됩니다."
+    )
+    @GetMapping("/api/v1/search-logs")
+    public CustomResponse<Void> recordSearchLog(
+            @Parameter(name = "keyword", description = "검색 키워드", example = "유산균")
+            @RequestParam String keyword) {
+        supplementService.recordSearchLog(keyword);
+        return CustomResponse.ok(null);
+    }
+
+
 //    @PostMapping("/by-purposes")
 //    @Operation(summary = "목적별 영양소 및 영양제 조회", description = "선택한 목적에 맞는 성분 및 관련 영양제를 반환합니다.")
 //    @ApiResponses({

--- a/src/main/java/com/vitacheck/dto/SupplementDto.java
+++ b/src/main/java/com/vitacheck/dto/SupplementDto.java
@@ -2,8 +2,10 @@ package com.vitacheck.dto;
 
 import com.vitacheck.domain.Supplement;
 import com.vitacheck.domain.mapping.SupplementIngredient;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -115,4 +117,26 @@ public class SupplementDto {
             }
         }
     }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class KeywordSearchSupplementBasedCursor {
+        private List<KeywordSearchSupplement> supplements;
+        private Long nextCursor;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class KeywordSearchSupplement{
+        private Long cursorId;  // 인기도 + supplementid
+        private String supplementName;
+        private String coupangUrl;
+        private String imageUrl;
+    }
+
+
 }

--- a/src/main/java/com/vitacheck/repository/BrandRepository.java
+++ b/src/main/java/com/vitacheck/repository/BrandRepository.java
@@ -3,6 +3,9 @@ package com.vitacheck.repository;
 import com.vitacheck.domain.Brand;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface BrandRepository extends JpaRepository<Brand, Long> {
     String existsByName(String name);
+    List<Brand> findByNameContainingIgnoreCase(String keyword);
 }

--- a/src/main/java/com/vitacheck/repository/IngredientRepository.java
+++ b/src/main/java/com/vitacheck/repository/IngredientRepository.java
@@ -7,8 +7,11 @@ import java.util.List;
 import java.util.Optional;
 
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+
     Optional<Ingredient> findByName(String name);
     List<Ingredient> findByNameContainingIgnoreCase(String keyword);
-
     String existsByName(String name);
+
 }
+
+

--- a/src/main/java/com/vitacheck/repository/PurposeCategoryRepository.java
+++ b/src/main/java/com/vitacheck/repository/PurposeCategoryRepository.java
@@ -36,3 +36,5 @@ public interface PurposeCategoryRepository extends JpaRepository<PurposeCategory
         """, nativeQuery = true)
     List<Object[]> findPurposeWithLimitedSupplements(@Param("goals") List<String> goals);
 }
+
+

--- a/src/main/java/com/vitacheck/repository/SupplementRepository.java
+++ b/src/main/java/com/vitacheck/repository/SupplementRepository.java
@@ -20,7 +20,8 @@ public interface SupplementRepository extends JpaRepository<Supplement, Long>, S
 
     @Query("""
            SELECT s FROM Supplement s JOIN FETCH s.supplementIngredients si
-           JOIN FETCH si.ingredient i WHERE s.id = :id
+           JOIN FETCH si.ingredient i WHERE s.id = :
+                      id
            """)
     Optional<Supplement> findByIdWithIngredients(@Param("id") Long id);
 
@@ -37,5 +38,65 @@ public interface SupplementRepository extends JpaRepository<Supplement, Long>, S
     WHERE s.id = :id
 """)
     Optional<Supplement> findByIdWithBrandAndIngredients(@Param("id") Long id);
+
+
+    @Query(
+            value = """
+                WITH matched_supplements AS (
+                    -- 1) 성분명 매칭
+                    SELECT DISTINCT si.supplement_id AS id
+                    FROM ingredients i
+                    JOIN supplement_ingredients si ON si.ingredient_id = i.id
+                    WHERE i.name LIKE CONCAT('%', :keyword, '%')
+                
+                    UNION
+                
+                    -- 2) 브랜드명 매칭
+                    SELECT DISTINCT s.id
+                    FROM brands b
+                    JOIN supplements s ON s.brand_id = b.id
+                    WHERE b.name LIKE CONCAT('%', :keyword, '%')
+                
+                    UNION
+                
+                    -- 3) 제품명 매칭
+                    SELECT DISTINCT s.id
+                    FROM supplements s
+                    WHERE s.name LIKE CONCAT('%', :keyword, '%')
+                ),
+                log_counts AS (
+                    SELECT sl.keyword AS supplement_name,
+                           COUNT(*) AS popularity_count
+                    FROM search_logs sl
+                    WHERE sl.category = 'SUPPLEMENT'
+                      AND sl.created_at >= CURDATE() - INTERVAL 3 DAY
+                    GROUP BY sl.keyword
+                )
+                        
+                SELECT s.id AS supplementId,
+                       s.name AS supplementName,
+                       s.coupang_url AS coupangUrl,
+                       s.image_url AS imageUrl,
+                       COALESCE(lc.popularity_count, 0) AS popularity,
+                       (COALESCE(lc.popularity_count, 0) * 1000000 + s.id) AS cursorId
+                FROM supplements s
+                JOIN matched_supplements ms ON ms.id = s.id
+                LEFT JOIN log_counts lc ON lc.supplement_name = s.name
+                WHERE (:cursorId IS NULL OR (COALESCE(lc.popularity_count, 0) * 1000000 + s.id) < :cursorId)
+                ORDER BY cursorId DESC
+                LIMIT :limit;
+
+        """,
+            nativeQuery = true
+    )
+    List<Object[]> findSupplementsByKeywordWithPopularity(
+            @Param("keyword") String keyword,
+            @Param("cursorId") Long cursorId,
+            @Param("limit") int limit
+
+    );
+
+
+
 
 }

--- a/src/main/java/com/vitacheck/service/SupplementService.java
+++ b/src/main/java/com/vitacheck/service/SupplementService.java
@@ -316,4 +316,52 @@ public class SupplementService {
             return PopularSupplementDto.from(supplement, searchCount);
         });
     }
+
+
+    public SupplementDto.KeywordSearchSupplementBasedCursor searchSupplements(
+            String keyword, Long cursor,  int size) {
+        List<Object[]> rows = supplementRepository.findSupplementsByKeywordWithPopularity(keyword, cursor, size+1);
+
+        List<SupplementDto.KeywordSearchSupplement> supplements = rows.stream()
+                .limit(size) // size까지만 DTO 변환
+                .map(row -> SupplementDto.KeywordSearchSupplement.builder()
+                        .cursorId((Long) row[5])
+                        .supplementName((String) row[1])
+                        .coupangUrl((String) row[2])
+                        .imageUrl((String) row[3])
+                        .build())
+                .toList();
+
+        // nextCursor 계산
+        Long nextCursor = null;
+        if (rows.size() > size) {
+            Object[] lastRow = rows.get(size); // size+1 번째 데이터
+            nextCursor = ((Number) lastRow[5]).longValue(); // ✅ cursorId를 꺼내야 함
+        }
+
+        return SupplementDto.KeywordSearchSupplementBasedCursor.builder()
+                .supplements(supplements)
+                .nextCursor(nextCursor)
+                .build();
+    }
+
+    public void recordSearchLog(String keyword) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication.getPrincipal().equals("anonymousUser")) {
+            // 🔹 미로그인 사용자 로그
+            searchLogService.logSearch(null, keyword, SearchCategory.KEYWORD, null, null);
+        } else {
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            User user = userDetails.getUser();
+
+            LocalDate birthDate = user.getBirthDate();
+            int age = Period.between(birthDate, LocalDate.now()).getYears();
+
+            // 🔹 로그인 사용자 로그
+            searchLogService.logSearch(user.getId(), keyword, SearchCategory.KEYWORD, age, user.getGender());
+        }
+    }
+
 }


### PR DESCRIPTION
Close #277 

## 📝 작업 내용
통합 검색 로직을 수정하고, cursor 페이지 제너레이션 도입하여 속도를 개선함
페이지 제너레이션으로 인해, 여러번 검색 api가 호출되기 때문에, 검색 api와 검색 기록 api 를 따로 분리함

## ✅ 변경 사항

- [x] Supplement(reposiotry, service, dto, controller 수정) - 검색 로직 분리 + 페이지 제너레이션 구현

1. 검색 로직은 다음과 같이 변경하였습니다.

     통합 검색 api → 성분 검색  api + 제품 검색 api +검색기록 api 로 분리

2. 제품 검색에는 아래의 경우의 수를 고려하였습니다.
    1) 키워드로 매칭된 성분을 포함한 제품
    2) 키워드로 매칭된 브랜드와 연관된 제품
    3) 키워드를 제품 이름에 포함하여 매칭된 제품

- [x] Ingredient (controller에서 swagger 설명 추가)



## 📷 스크린샷 (선택)
<img width="601" height="519" alt="image" src="https://github.com/user-attachments/assets/45942afc-9286-4aff-8693-249f1e4ea3b1" />

<img width="670" height="523" alt="image" src="https://github.com/user-attachments/assets/c9c55b2f-1fbe-452d-af69-ab845cedff12" />

<img width="545" height="278" alt="image" src="https://github.com/user-attachments/assets/23b42a7b-c848-4ec9-acb4-22448df5a034" />

## 💬 리뷰어에게
- cursor ID는 인기도와 supplementId를 이용하여 만든 cursor용 ID입니다. (인기도 *1000000 + supplementId로 구성)
- 검색과 검색 기록 로직을 분리하였기 때문에, 검색할 때, /api/v1/search-logs 를 호출해주어야합니다. (성분 검색 예외 - 내부에 로직 있음)
