### PR TITLE
[REFRACTOR#277] 성분 검색 api에서 검색 기록 로직 분리

### DIFF
--- a/src/main/java/com/vitacheck/controller/SupplementController.java
+++ b/src/main/java/com/vitacheck/controller/SupplementController.java
@@ -90,8 +90,8 @@ public class SupplementController {
     }
 
     @Operation(
-            summary = "제품 검색 기록 API By 박지영",
-            description = " 검색에서 검색한 키워드를 기록합니다. 제품 검색을 사용할 때만 이 api를 추가로 사용해주시면 됩니다."
+            summary = "검색 기록 API By 박지영",
+            description = " 검색에서 검색한 키워드를 DB에 저장/기록 합니다. 모든 검색 기능에서 이 api를 같이 호출해주시면 됩니다."
     )
     @GetMapping("/api/v1/search-logs")
     public CustomResponse<Void> recordSearchLog(

--- a/src/main/java/com/vitacheck/service/IngredientService.java
+++ b/src/main/java/com/vitacheck/service/IngredientService.java
@@ -57,21 +57,6 @@ public class IngredientService {
             throw new CustomException(ErrorCode.INGREDIENT_NOT_FOUND);
         }
 
-        // 2. 사용자 정보 가져오기 (로그인 여부에 따라 기본값 처리)
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null || !authentication.isAuthenticated() || authentication.getPrincipal().equals("anonymousUser")) {
-            // 🔹 검색 로그 저장(미로그인)
-            searchLogService.logSearch(null, keyword, SearchCategory.INGREDIENT, null,null);
-        } else {
-            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-            User user = userDetails.getUser();
-            LocalDate birthDate = user.getBirthDate();
-            int age = Period.between(birthDate, LocalDate.now()).getYears();
-            // 🔹 검색 로그 저장(로그인)
-            searchLogService.logSearch(user.getId(), keyword, SearchCategory.INGREDIENT, age, user.getGender());
-        }
-
 
         return ingredients.stream()
                 .map(ingredient -> IngredientResponseDTO.IngredientName.builder()


### PR DESCRIPTION
Close #277 

## 📝 작업 내용
성분 검색도 검색 api와 검색 기록 api를 분리하여 통일성을 확보함

## ✅ 변경 사항
- [x] IngredientService 수정 (검색 api에서 검색 기록 로직을 분리함)


## 📷 스크린샷 (선택)
## 💬 리뷰어에게
검색하면 예외 없이 /api/v1/search-logs를 호출해주세요