### PR TITLE
[BUG#298] 내 알림 설정 변경 api 오류 수정

### DIFF
--- a/src/main/java/com/vitacheck/controller/NotificationSettingsController.java
+++ b/src/main/java/com/vitacheck/controller/NotificationSettingsController.java
@@ -51,12 +51,12 @@ public class NotificationSettingsController {
                             schema = @Schema(implementation = NotificationSettingsDto.UpdateRequest.class),
                             examples = {
                                     @ExampleObject(
-                                            name = "섭취 알림 끄기",
+                                            name = "섭취 알림 켜기/끄기",
                                             value = "{\"type\": \"INTAKE\", \"channel\": \"PUSH\", \"isEnabled\": false}",
                                             summary = "섭취 푸시 알림 끄기 예시"
                                     ),
                                     @ExampleObject(
-                                            name = "이벤트 알림 켜기",
+                                            name = "이벤트 알림 켜기/끄기",
                                             value = "{\"type\": \"EVENT\", \"channel\": \"SMS\", \"isEnabled\": true}",
                                             summary = "이벤트 SMS 알림 켜기 예시"
                                     )

--- a/src/main/java/com/vitacheck/service/NotificationSettingsService.java
+++ b/src/main/java/com/vitacheck/service/NotificationSettingsService.java
@@ -49,7 +49,7 @@ public class NotificationSettingsService {
                 .findByUserAndTypeAndChannel(user, request.getType(), request.getChannel())
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REQUEST)); // 존재하지 않는 설정을 변경하려는 경우
 
-        setting.setIsEnabled(request.isEnabled());
+        setting.setIsEnabled(!setting.isEnabled());
 
         notificationSettingsRepository.save(setting);
     }


### PR DESCRIPTION
Close #298 

## 📝 작업 내용
내 알림 설정 변경 api 에서 알림이 켜지지않는 오류 수정

## ✅ 변경 사항
- [ ]NotificationSettings(Service 로직 수정, Controller - swagger 설명ㅡ 수정)



## 📷 스크린샷 (선택)
DB에서 사용자 설정이 변경되는것을 확인했습니다.
<img width="431" height="283" alt="image" src="https://github.com/user-attachments/assets/56152936-924c-416d-befd-413a0174740a" />

## 💬 리뷰어에게
입력을 받으면 현재 상태를 반대로 (ex. 끄기 → 켜기, 켜기 → 끄기)로 동작하도록 로직을 변경하였기 때문에,   "isEnabled": true를 입력받지 않아도 됩니다. 추후 프론트와 isEnabled 값을 어떻게 할지 논의하겠습니다.