### PR TITLE
[REFRACTOR] 인기 검색 성분 조회 api url 수정(미로그인도 접근 가능)

### DIFF
--- a/src/main/java/com/vitacheck/controller/IngredientController.java
+++ b/src/main/java/com/vitacheck/controller/IngredientController.java
@@ -98,7 +98,7 @@ public class IngredientController {
 
 
     @Operation(summary = "인기 검색 성분 조회", description = "가장 많이 검색된 성분을 순서대로 조회합니다.")
-    @GetMapping("/popular-ingredients")
+    @GetMapping("/api/v1/ingredients/popular")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "인기 검색 성분 조회",
                     content = @Content(examples = @ExampleObject(value = "{\"isSuccess\":true,\"code\":\"COMMON200\",\"message\":\"성공적으로 요청을 수행했습니다.\",\"result\":\"FCM 토큰이 업데이트되었습니다.\"}"))),


### PR DESCRIPTION
Close #303 

## 📝 작업 내용
인기 검색 성분 조회 api url 수정(미로그인도 접근 가능)

## ✅ 변경 사항
- [x] IngredientController에서 api 수정 (/ingredients-popular →/api/v1/ingredients/popular)
→ 미로그인 시에도 접근 가능하도록, 이미 permit 되어있는 "/api/v1/ingredients/**"에 속하도록 url 변경함


## 📷 스크린샷 (선택)
<img width="647" height="591" alt="image" src="https://github.com/user-attachments/assets/7aef3357-8b12-4c3b-b1bc-baeddcf7f993" />

## 💬 리뷰어에게