### PR TITLE
[REFRACTOR#322] 배포 브랜치 변경 ( deploy → main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: VitaCheck Backend CI/CD
 # 이 워크플로우가 언제 실행될지를 정의하는 '트리거' 설정입니다.
 on:
   push:
-    branches: [ develop ]  # develop 브랜치에 push 될 때
+    branches: [ main ]  # develop 브랜치에 push 될 때
 
 # 실제 수행할 작업(Job)들을 정의합니다.
 jobs:


### PR DESCRIPTION


## 📝 작업 내용
배포 브랜치 변경 ( deploy → main)


## ✅ 변경 사항
- [x] .github/workflows/ci.yml 파일 변경 (develop → main)


## 📷 스크린샷 (선택)
<img width="185" height="71" alt="image" src="https://github.com/user-attachments/assets/1b237cef-9dcb-46f0-bc74-497deeb9f00e" />



## 💬 리뷰어에게
기존 개발 과정에서 develop 을 배포 브랜치로 사용하였으나, 이후 출시를 목표로 디벨롭하기로 하여 main 브랜치를 배포 브랜치로 변경함.(Vitacheck version2)

