### PR TITLE
fix(#354): 회원가입 데이터 처리 user 모듈에서 진행하도록 변경

### DIFF
--- a/module-auth/build.gradle
+++ b/module-auth/build.gradle
@@ -15,6 +15,7 @@ repositories {
 dependencies {
     // 공통 모듈과 사용자 모듈에 의존합니다.
     implementation project(":module-common")
+    implementation project(":module-user")
 
     // Spring Security, OAuth2, JWT 관련 의존성을 추가합니다.
     implementation 'org.springframework.boot:spring-boot-starter-web' // ◀◀ Controller를 위해 추가

--- a/module-auth/src/main/java/com/vitacheck/auth/config/SecurityConfig.java
+++ b/module-auth/src/main/java/com/vitacheck/auth/config/SecurityConfig.java
@@ -60,6 +60,9 @@ public class SecurityConfig {
             "/health",
             "/clova-ocr/**",
 
+            // terms
+            "/api/v1/user/terms",
+
             // test
             "/api/v1/test"
     };

--- a/module-auth/src/main/java/com/vitacheck/auth/config/jwt/JwtUtil.java
+++ b/module-auth/src/main/java/com/vitacheck/auth/config/jwt/JwtUtil.java
@@ -1,7 +1,7 @@
 package com.vitacheck.auth.config.jwt;
 
 import com.vitacheck.auth.dto.AuthDto;
-import com.vitacheck.auth.dto.AuthUserDto;
+import com.vitacheck.user.dto.AuthUserDto;
 import com.vitacheck.auth.dto.OAuthAttributes;
 import com.vitacheck.common.enums.Gender;
 import io.jsonwebtoken.*;

--- a/module-auth/src/main/java/com/vitacheck/auth/config/oauth/OAuth2SuccessHandler.java
+++ b/module-auth/src/main/java/com/vitacheck/auth/config/oauth/OAuth2SuccessHandler.java
@@ -1,9 +1,9 @@
 package com.vitacheck.auth.config.oauth;
 
 import com.vitacheck.auth.config.jwt.JwtUtil;
-import com.vitacheck.auth.dto.AuthUserDto;
+import com.vitacheck.user.dto.AuthUserDto;
 import com.vitacheck.auth.dto.OAuthAttributes;
-import com.vitacheck.auth.service.provider.AuthUserProvider; // provider를 import 합니다.
+import com.vitacheck.user.service.provider.AuthUserProvider;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/module-auth/src/main/java/com/vitacheck/auth/service/AuthService.java
+++ b/module-auth/src/main/java/com/vitacheck/auth/service/AuthService.java
@@ -2,13 +2,13 @@ package com.vitacheck.auth.service;
 
 import com.vitacheck.auth.config.jwt.JwtUtil;
 import com.vitacheck.auth.dto.AuthDto;
-import com.vitacheck.auth.dto.AuthUserDto;
-import com.vitacheck.auth.dto.CreateUserRequest;
+import com.vitacheck.user.dto.AuthUserDto;
 import com.vitacheck.auth.dto.OAuthAttributes;
-import com.vitacheck.auth.service.provider.AuthUserProvider;
-import com.vitacheck.auth.service.provider.UserRegistrationService;
 import com.vitacheck.common.code.ErrorCode;
 import com.vitacheck.common.exception.CustomException;
+import com.vitacheck.user.dto.CreateUserRequest;
+import com.vitacheck.user.service.provider.AuthUserProvider;
+import com.vitacheck.user.service.provider.UserRegistrationService;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/module-user/build.gradle
+++ b/module-user/build.gradle
@@ -14,7 +14,6 @@ repositories {
 
 dependencies {
     implementation project(":module-common")
-    implementation project(":module-auth")
     implementation 'org.springframework.boot:spring-boot-starter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/module-user/src/main/java/com/vitacheck/user/controller/UserController.java
+++ b/module-user/src/main/java/com/vitacheck/user/controller/UserController.java
@@ -71,6 +71,7 @@ public class UserController {
         UserDto.InfoResponse updatedInfo = userService.updateMyInfo(user.getEmail(), request); // ◀◀ user.getEmail() 사용
         return CustomResponse.ok(updatedInfo);
     }
+    
 
     @Operation(summary = "프로필 사진 URL 업데이트", description = "사용자 본인의 프로필 사진을 변경합니다.")
     @ApiResponses(value = {

--- a/module-user/src/main/java/com/vitacheck/user/dto/AuthUserDto.java
+++ b/module-user/src/main/java/com/vitacheck/user/dto/AuthUserDto.java
@@ -1,4 +1,4 @@
-package com.vitacheck.auth.dto;
+package com.vitacheck.user.dto;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/module-user/src/main/java/com/vitacheck/user/dto/CreateUserRequest.java
+++ b/module-user/src/main/java/com/vitacheck/user/dto/CreateUserRequest.java
@@ -1,6 +1,6 @@
-package com.vitacheck.auth.dto;
+package com.vitacheck.user.dto;
 
-import com.vitacheck.common.enums.Gender; // common 모듈의 Gender는 사용 가능
+import com.vitacheck.common.enums.Gender;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/module-user/src/main/java/com/vitacheck/user/service/AuthUserProviderImpl.java
+++ b/module-user/src/main/java/com/vitacheck/user/service/AuthUserProviderImpl.java
@@ -1,8 +1,8 @@
 package com.vitacheck.user.service;
 
-import com.vitacheck.auth.dto.AuthUserDto;
-import com.vitacheck.auth.service.provider.AuthUserProvider;
+import com.vitacheck.user.dto.AuthUserDto;
 import com.vitacheck.user.repository.UserRepository;
+import com.vitacheck.user.service.provider.AuthUserProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/module-user/src/main/java/com/vitacheck/user/service/UserRegistrationServiceImpl.java
+++ b/module-user/src/main/java/com/vitacheck/user/service/UserRegistrationServiceImpl.java
@@ -1,12 +1,12 @@
 package com.vitacheck.user.service;
 
-import com.vitacheck.auth.dto.CreateUserRequest;
-import com.vitacheck.auth.service.provider.UserRegistrationService;
 import com.vitacheck.user.domain.Role;
 import com.vitacheck.user.domain.User;
 import com.vitacheck.user.domain.UserStatus;
+import com.vitacheck.user.dto.CreateUserRequest;
 import com.vitacheck.user.dto.UserSignedUpEvent;
 import com.vitacheck.user.repository.UserRepository;
+import com.vitacheck.user.service.provider.UserRegistrationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;

--- a/module-user/src/main/java/com/vitacheck/user/service/provider/AuthUserProvider.java
+++ b/module-user/src/main/java/com/vitacheck/user/service/provider/AuthUserProvider.java
@@ -1,6 +1,6 @@
-package com.vitacheck.auth.service.provider;
+package com.vitacheck.user.service.provider;
 
-import com.vitacheck.auth.dto.AuthUserDto;
+import com.vitacheck.user.dto.AuthUserDto;
 
 import java.util.Optional;
 

--- a/module-user/src/main/java/com/vitacheck/user/service/provider/UserRegistrationService.java
+++ b/module-user/src/main/java/com/vitacheck/user/service/provider/UserRegistrationService.java
@@ -1,6 +1,6 @@
-package com.vitacheck.auth.service.provider;
+package com.vitacheck.user.service.provider;
 
-import com.vitacheck.auth.dto.CreateUserRequest;
+import com.vitacheck.user.dto.CreateUserRequest;
 
 public interface UserRegistrationService {
     void registerUser(CreateUserRequest request);


### PR DESCRIPTION
Close #354 

## 📝 작업 내용
AuthController에는 API 엔드포인트만 남기고 데이터 처리는 user 모듈에서 하도록 변경

## ✅ 변경 사항
- [x] AuthDto, AuthContextProvider user 모듈로 리팩토링

## 💬 리뷰어에게
추후 terms, notification 분리 고려해보겠습니다. 