### PR TITLE
fix(#377): 알림 설정 안되는 버그 해결

### DIFF
--- a/src/main/java/com/vitacheck/Notification/service/NotificationSettingsService.java
+++ b/src/main/java/com/vitacheck/Notification/service/NotificationSettingsService.java
@@ -19,12 +19,12 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class NotificationSettingsService {
 
     private final NotificationSettingsRepository notificationSettingsRepository;
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
     public List<NotificationSettingsDto> getNotificationSettings(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));


### PR DESCRIPTION
Close #377 

## 📝 작업 내용
notificationSettingsService에서 Transactional 변경

## ✅ 변경 사항
- [x] 클래스 전체의 Transactional(readOnly = true) 어노테이션 제거
- [x] 조회 메소드에만 해당 어노테이션 추가


## 📷 스크린샷 (선택)
## 💬 리뷰어에게