### PR TITLE
fix(#385): Notification 관련 파일 user 모듈로 리팩토링

### DIFF
--- a/module-user/src/main/java/com/vitacheck/user/notification/domain/NotificationChannel.java
+++ b/module-user/src/main/java/com/vitacheck/user/notification/domain/NotificationChannel.java
@@ -1,4 +1,4 @@
-package com.vitacheck.Notification.domain;
+package com.vitacheck.user.notification.domain;
 
 public enum NotificationChannel {
     EMAIL,

--- a/module-user/src/main/java/com/vitacheck/user/notification/domain/NotificationSettings.java
+++ b/module-user/src/main/java/com/vitacheck/user/notification/domain/NotificationSettings.java
@@ -1,4 +1,4 @@
-package com.vitacheck.Notification.domain;
+package com.vitacheck.user.notification.domain;
 
 
 import com.vitacheck.common.entity.BaseTimeEntity;

--- a/module-user/src/main/java/com/vitacheck/user/notification/domain/NotificationType.java
+++ b/module-user/src/main/java/com/vitacheck/user/notification/domain/NotificationType.java
@@ -1,4 +1,4 @@
-package com.vitacheck.Notification.domain;
+package com.vitacheck.user.notification.domain;
 
 public enum NotificationType {
     EVENT, // 이벤트 및 혜택

--- a/module-user/src/main/java/com/vitacheck/user/notification/dto/NotificationSettingsDto.java
+++ b/module-user/src/main/java/com/vitacheck/user/notification/dto/NotificationSettingsDto.java
@@ -1,8 +1,8 @@
-package com.vitacheck.Notification.dto;
+package com.vitacheck.user.notification.dto;
 
-import com.vitacheck.Notification.domain.NotificationChannel;
-import com.vitacheck.Notification.domain.NotificationSettings;
-import com.vitacheck.Notification.domain.NotificationType;
+import com.vitacheck.user.notification.domain.NotificationChannel;
+import com.vitacheck.user.notification.domain.NotificationSettings;
+import com.vitacheck.user.notification.domain.NotificationType;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/module-user/src/main/java/com/vitacheck/user/notification/repository/NotificationSettingsRepository.java
+++ b/module-user/src/main/java/com/vitacheck/user/notification/repository/NotificationSettingsRepository.java
@@ -1,9 +1,9 @@
-package com.vitacheck.Notification.repository;
+package com.vitacheck.user.notification.repository;
 
-import com.vitacheck.Notification.domain.NotificationChannel;
-import com.vitacheck.Notification.domain.NotificationSettings;
-import com.vitacheck.Notification.domain.NotificationType;
 import com.vitacheck.user.domain.User;
+import com.vitacheck.user.notification.domain.NotificationChannel;
+import com.vitacheck.user.notification.domain.NotificationSettings;
+import com.vitacheck.user.notification.domain.NotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/module-user/src/main/java/com/vitacheck/user/notification/service/NotificationSettingsService.java
+++ b/module-user/src/main/java/com/vitacheck/user/notification/service/NotificationSettingsService.java
@@ -1,13 +1,13 @@
-package com.vitacheck.Notification.service;
+package com.vitacheck.user.notification.service;
 
-import com.vitacheck.Notification.domain.NotificationChannel;
-import com.vitacheck.Notification.domain.NotificationSettings;
-import com.vitacheck.Notification.domain.NotificationType;
-import com.vitacheck.Notification.dto.NotificationSettingsDto;
-import com.vitacheck.common.exception.CustomException;
 import com.vitacheck.common.code.ErrorCode;
-import com.vitacheck.Notification.repository.NotificationSettingsRepository;
+import com.vitacheck.common.exception.CustomException;
 import com.vitacheck.user.domain.User;
+import com.vitacheck.user.notification.domain.NotificationChannel;
+import com.vitacheck.user.notification.domain.NotificationSettings;
+import com.vitacheck.user.notification.domain.NotificationType;
+import com.vitacheck.user.notification.dto.NotificationSettingsDto;
+import com.vitacheck.user.notification.repository.NotificationSettingsRepository;
 import com.vitacheck.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,64 +24,39 @@ public class NotificationSettingsService {
     private final NotificationSettingsRepository notificationSettingsRepository;
     private final UserRepository userRepository;
 
-    /**
-     * 사용자의 알림 설정을 조회합니다. 설정이 없으면 빈 리스트를 반환합니다.
-     */
     @Transactional(readOnly = true)
     public List<NotificationSettingsDto> getNotificationSettings(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
         List<NotificationSettings> settings = notificationSettingsRepository.findByUser(user);
-
         return settings.stream()
                 .map(NotificationSettingsDto::from)
                 .collect(Collectors.toList());
     }
 
-    /**
-     * 사용자의 특정 알림 설정을 업데이트합니다.
-     * 설정이 없는 사용자의 경우, 기본 설정을 먼저 생성한 후 업데이트를 수행합니다.
-     */
     @Transactional
     public void updateNotificationSetting(Long userId, NotificationSettingsDto.UpdateRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        List<NotificationSettings> settings = notificationSettingsRepository.findByUser(user);
-
-        // 설정이 없는 신규 유저라면 기본값을 먼저 생성
-        if (settings.isEmpty()) {
-            settings = createDefaultSettingsForUser(user);
-        }
-
-        // 요청에 맞는 설정을 찾아서 상태 변경
-        NotificationSettings settingToUpdate = settings.stream()
-                .filter(s -> s.getType() == request.getType() && s.getChannel() == request.getChannel())
-                .findFirst()
+        NotificationSettings settingToUpdate = notificationSettingsRepository
+                .findByUserAndTypeAndChannel(user, request.getType(), request.getChannel())
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REQUEST));
-
         settingToUpdate.setIsEnabled(request.isEnabled());
-
         notificationSettingsRepository.save(settingToUpdate);
     }
 
-    /**
-     * 특정 사용자를 위한 기본 알림 설정을 생성하고 DB에 저장합니다.
-     * @return 저장된 NotificationSettings 엔티티 리스트를 반환합니다.
-     */
+    // 이 메서드는 UserEventService에서만 호출됩니다.
     @Transactional
-    public List<NotificationSettings> createDefaultSettingsForUser(User user) {
+    public void createDefaultSettingsForUser(User user) {
         List<NotificationSettings> defaultSettings = Arrays.stream(NotificationType.values())
                 .flatMap(type -> Arrays.stream(NotificationChannel.values())
                         .map(channel -> NotificationSettings.builder()
                                 .user(user)
                                 .type(type)
                                 .channel(channel)
-                                .isEnabled(true) // 기본값은 모두 ON
+                                .isEnabled(true)
                                 .build()))
                 .collect(Collectors.toList());
-
-        return notificationSettingsRepository.saveAll(defaultSettings);
+        notificationSettingsRepository.saveAll(defaultSettings);
     }
 }

--- a/src/main/java/com/vitacheck/Notification/controller/NotificationSettingsController.java
+++ b/src/main/java/com/vitacheck/Notification/controller/NotificationSettingsController.java
@@ -1,11 +1,11 @@
 package com.vitacheck.Notification.controller;
 
-import com.vitacheck.Notification.dto.NotificationSettingsDto;
+import com.vitacheck.user.notification.dto.NotificationSettingsDto;
 import com.vitacheck.common.exception.CustomException;
 import com.vitacheck.common.CustomResponse;
 import com.vitacheck.common.code.ErrorCode;
 import com.vitacheck.Notification.service.NotificationScheduler;
-import com.vitacheck.Notification.service.NotificationSettingsService;
+import com.vitacheck.user.notification.service.NotificationSettingsService;
 import com.vitacheck.common.security.AuthenticatedUser;
 import com.vitacheck.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/src/main/java/com/vitacheck/Notification/domain/NotificationLog.java
+++ b/src/main/java/com/vitacheck/Notification/domain/NotificationLog.java
@@ -1,6 +1,8 @@
 package com.vitacheck.Notification.domain;
 
 import com.vitacheck.user.domain.User;
+import com.vitacheck.user.notification.domain.NotificationChannel;
+import com.vitacheck.user.notification.domain.NotificationType;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;

--- a/src/main/java/com/vitacheck/Notification/service/NotificationScheduler.java
+++ b/src/main/java/com/vitacheck/Notification/service/NotificationScheduler.java
@@ -1,12 +1,12 @@
 package com.vitacheck.Notification.service;
 
 import com.vitacheck.Intake.domain.RoutineDayOfWeek;
-import com.vitacheck.Notification.domain.NotificationChannel;
+import com.vitacheck.user.notification.domain.NotificationChannel;
 import com.vitacheck.Notification.domain.NotificationRoutine;
-import com.vitacheck.Notification.domain.NotificationSettings;
-import com.vitacheck.Notification.domain.NotificationType;
+import com.vitacheck.user.notification.domain.NotificationSettings;
+import com.vitacheck.user.notification.domain.NotificationType;
 import com.vitacheck.Notification.repository.NotificationRoutineRepository;
-import com.vitacheck.Notification.repository.NotificationSettingsRepository; // Repository 주입
+import com.vitacheck.user.notification.repository.NotificationSettingsRepository; // Repository 주입
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/vitacheck/Term/service/TermsService.java
+++ b/src/main/java/com/vitacheck/Term/service/TermsService.java
@@ -2,12 +2,12 @@ package com.vitacheck.Term.service;
 
 import com.vitacheck.Term.domain.UserTermsAgreement;
 import com.vitacheck.Term.domain.Terms;
-import com.vitacheck.Notification.domain.NotificationSettings;
-import com.vitacheck.Notification.domain.NotificationType;
+import com.vitacheck.user.notification.domain.NotificationSettings;
+import com.vitacheck.user.notification.domain.NotificationType;
 import com.vitacheck.Term.dto.TermsDto;
 import com.vitacheck.common.exception.CustomException;
 import com.vitacheck.common.code.ErrorCode;
-import com.vitacheck.Notification.repository.NotificationSettingsRepository;
+import com.vitacheck.user.notification.repository.NotificationSettingsRepository;
 import com.vitacheck.Term.repository.TermsRepository;
 import com.vitacheck.Term.repository.UserTermsAgreementRepository;
 import com.vitacheck.user.domain.User;

--- a/src/main/java/com/vitacheck/VitacheckBeApplication.java
+++ b/src/main/java/com/vitacheck/VitacheckBeApplication.java
@@ -3,10 +3,12 @@ package com.vitacheck;
 import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.TimeZone;
 
 @SpringBootApplication(scanBasePackages = "com.vitacheck")
+@EnableJpaAuditing
 public class VitacheckBeApplication {
 
     @PostConstruct

--- a/src/main/java/com/vitacheck/etc/UserCleanUpService.java
+++ b/src/main/java/com/vitacheck/etc/UserCleanUpService.java
@@ -4,7 +4,7 @@ import com.vitacheck.Activity.repository.IngredientLikeRepository;
 import com.vitacheck.Activity.repository.SearchLogRepository;
 import com.vitacheck.Activity.repository.SupplementLikeRepository;
 import com.vitacheck.Notification.repository.NotificationRoutineRepository;
-import com.vitacheck.Notification.repository.NotificationSettingsRepository;
+import com.vitacheck.user.notification.repository.NotificationSettingsRepository;
 import com.vitacheck.Term.repository.UserTermsAgreementRepository;
 import com.vitacheck.Intake.repository.CustomSupplementRepository;
 import com.vitacheck.Intake.repository.IntakeRecordRepository;

--- a/src/main/java/com/vitacheck/etc/UserEventService.java
+++ b/src/main/java/com/vitacheck/etc/UserEventService.java
@@ -1,6 +1,6 @@
 package com.vitacheck.etc;
 
-import com.vitacheck.Notification.service.NotificationSettingsService;
+import com.vitacheck.user.notification.service.NotificationSettingsService;
 import com.vitacheck.Term.service.TermsService;
 import com.vitacheck.Term.domain.Terms;
 import com.vitacheck.Term.domain.UserTermsAgreement;
@@ -32,7 +32,6 @@ public class UserEventService {
         if (event.getAgreeTermIds() != null && !event.getAgreeTermIds().isEmpty()) {
             List<Terms> termsList = termsRepository.findAllById(event.getAgreeTermIds());
 
-            // ✅ 이 부분을 빌더 패턴으로 수정합니다.
             List<UserTermsAgreement> agreements = termsList.stream()
                     .map(terms -> UserTermsAgreement.builder()
                             .user(event.getUser())
@@ -42,5 +41,8 @@ public class UserEventService {
 
             userTermsAgreementRepository.saveAll(agreements);
         }
+
+        notificationSettingsService.createDefaultSettingsForUser(event.getUser());
+        log.info("사용자 ID: {}의 기본 알림 설정을 생성했습니다.", event.getUser().getId());
     }
 }


### PR DESCRIPTION
Close #385 

## 📝 작업 내용
Notification 관련 파일들을 user 모듈로 리팩토링해 회원가입시 알림 설정이 저장되도록 바꿨습니다.
추가로 알림 설정 토글 관련 기능도 수정했습니다.

## ✅ 변경 사항
- [x] Notification 리팩토링
- [x] VitacheckBeApplication에 @EnableJpaAuditing 어노테이션 추가

## 💬 리뷰어에게
스웨거 테스트 완료