### PR TITLE
fix(#410): NotificationScheduler에 디버깅용 로그 추가

### DIFF
--- a/src/main/java/com/vitacheck/Notification/service/NotificationScheduler.java
+++ b/src/main/java/com/vitacheck/Notification/service/NotificationScheduler.java
@@ -32,41 +32,91 @@ public class NotificationScheduler {
         LocalTime currentTime = now.toLocalTime().withSecond(0).withNano(0);
         RoutineDayOfWeek routineDay = convertToRoutineDayOfWeek(now.getDayOfWeek());
 
-        if (routineDay == null) return;
+        log.info("===== NotificationScheduler 시작 =====");
+        log.info("현재 서버 시간: {}", now);
+        log.info("알림 검색 기준 시간 (초/나노초 제외): {}", currentTime);
+        log.info("알림 검색 기준 요일: {}", routineDay);
+
+        if (routineDay == null) {
+            log.warn("유효하지 않은 요일({})이므로 스케줄러를 종료합니다.", now.getDayOfWeek());
+            log.info("===== NotificationScheduler 종료 =====");
+            return;
+        }
 
         log.info("{} {}시 {}분에 발송될 알림을 찾습니다.", routineDay, currentTime.getHour(), currentTime.getMinute());
-        List<NotificationRoutine> routines = notificationRoutineRepository.findRoutinesToSend(routineDay, currentTime);
+        List<NotificationRoutine> routines;
+        try {
+            routines = notificationRoutineRepository.findRoutinesToSend(routineDay, currentTime);
+            log.info("DB 조회 결과: {}개의 발송 대상 루틴을 찾았습니다.", routines.size());
+        } catch (Exception e) {
+            log.error("findRoutinesToSend 쿼리 실행 중 오류 발생", e);
+            log.info("===== NotificationScheduler 종료 (DB 오류) =====");
+            return; // DB 오류 시 더 이상 진행하지 않음
+        }
 
         if (routines.isEmpty()) {
             log.info("발송할 알림이 없습니다.");
+            log.info("===== NotificationScheduler 종료 =====");
             return;
         }
 
         for (NotificationRoutine routine : routines) {
-            Optional<NotificationSettings> setting = notificationSettingsRepository.findByUserAndTypeAndChannel(
-                    routine.getUser(),
-                    NotificationType.INTAKE,
-                    NotificationChannel.PUSH
-            );
+            Long userId = routine.getUser() != null ? routine.getUser().getId() : null;
+            Long routineId = routine.getId();
+            log.info("--- 루틴 ID: {}, 사용자 ID: {} 처리 시작 ---", routineId, userId);
 
+            if (userId == null) {
+                log.warn("루틴 ID {}에 연결된 사용자 정보가 없습니다. 건너<0xEB><0x9A><0xA5>니다.", routineId);
+                continue;
+            }
+
+            Optional<NotificationSettings> settingOptional;
+            try {
+                settingOptional = notificationSettingsRepository.findByUserAndTypeAndChannel(
+                        routine.getUser(),
+                        NotificationType.INTAKE,
+                        NotificationChannel.PUSH
+                );
+            } catch (Exception e) {
+                log.error("사용자 ID {}의 알림 설정 조회 중 오류 발생 (루틴 ID: {})", userId, routineId, e);
+                continue; // 설정 조회 실패 시 해당 루틴 건너<0xEB><0x9A><0xA5>
+            }
+
+            boolean isPresent = settingOptional.isPresent();
+            boolean isEnabled = isPresent && settingOptional.get().isEnabled();
+            log.info("사용자 ID {}의 섭취 푸시(INTAKE/PUSH) 설정: 존재 여부={}, 활성화 여부={}", userId, isPresent, isEnabled);
             // 설정이 존재하고, isEnabled가 true일 때만 알림 발송
-            if (setting.isPresent() && setting.get().isEnabled()) {
+            if (isPresent && isEnabled) {
                 String fcmToken = routine.getUser().getFcmToken();
-                String title = "💊 영양제 복용 시간입니다!";
+                log.info("사용자 ID {}의 FCM 토큰: {}", userId, (fcmToken != null && !fcmToken.isEmpty()) ? "[존재]" : "[없음 또는 비어있음]");
+                if (fcmToken == null || fcmToken.isEmpty()) {
+                    log.warn("사용자 ID {}의 FCM 토큰이 없어 알림을 발송할 수 없습니다. (루틴 ID: {})", userId, routineId);
+                    continue; // 토큰 없으면 다음 루틴으로
+                }
 
+
+                String title = "💊 영양제 복용 시간입니다!";
                 String supplementName;
-                if (routine.isCustom()) {
+                if (routine.isCustom() && routine.getCustomSupplement() != null) {
                     supplementName = routine.getCustomSupplement().getName();
-                } else {
+                } else if (!routine.isCustom() && routine.getSupplement() != null) {
                     supplementName = routine.getSupplement().getName();
+                } else {
+                    supplementName = "[알 수 없는 영양제]"; // 예외 케이스 처리
+                    log.warn("루틴 ID {}의 영양제 정보(커스텀/카탈로그)를 찾을 수 없습니다.", routineId);
                 }
 
                 String body = String.format("'%s'를 복용할 시간이에요.", supplementName);
+
+                log.info("FCM 발송 시도: To={}, Title={}, Body={}", fcmToken, title, body);
+
                 fcmService.sendNotification(fcmToken, title, body);
             } else {
                 log.info("사용자 ID: {}님이 섭취 푸시 알림을 꺼두어 발송하지 않았습니다.", routine.getUser().getId());
             }
+            log.info("--- 루틴 ID: {} 처리 완료 ---", routineId);
         }
+        log.info("===== NotificationScheduler 종료 =====");
     }
 
     private RoutineDayOfWeek convertToRoutineDayOfWeek(DayOfWeek dayOfWeek) {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -78,3 +78,9 @@ server:
 vertex:
   api:
     url: "https://us-central1-aiplatform.googleapis.com/v1/projects/vitacheck-464904/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent"
+
+logging:
+  level:
+    org.hibernate.SQL: DEBUG # 실행되는 SQL 쿼리 로그 출력
+    org.hibernate.type.descriptor.sql: TRACE # SQL 바인딩 파라미터 로그 출력 ( ? 에 들어가는 값 확인)
+    com.vitacheck.Notification.service: DEBUG # 알림 관련 서비스 로깅 레벨 상세 설정 (이미 추가한 로그 확인용)


### PR DESCRIPTION
- 푸시 알림 미발송 문제의 원인을 파악하기 위해 `NotificationScheduler` 및 관련 로직에 상세 로깅을 추가했습니다.
- 실행 시점, 조회 대상 조건(시간, 요일), 조회 결과, 사용자 설정 확인 결과, FCM 토큰 유효성, FCM API 호출 시도 등의 정보를 로그로 남기도록 수정했습니다.
- 정확한 쿼리 실행 및 파라미터 확인을 위해 `application-prod.yml`에 Hibernate SQL 로깅 설정을 추가했습니다.

## ✅ 변경 사항
- [x] `NotificationScheduler.java` : 주요 로직 단계별 상세 로그 추가
- [x] `application-prod.yml` : Hibernate SQL 및 파라미터 로깅, 관련 서비스 로깅 레벨 설정 추가

## 💬 리뷰어에게
- 푸시 알림 미발송 문제 디버깅을 위해 로깅을 강화하는 PR입니다.
- 추가된 로그가 과도하거나 부족하지 않은지, 로깅 위치가 적절한지 검토 부탁드립니다.
- Merge 후 운영 환경에서 로그를 모니터링하여 원인을 파악할 예정입니다.